### PR TITLE
fix: drop overlay gets stuck when drag leaves over a nested element

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -147,6 +147,7 @@ export function App(): JSX.Element {
   const [activeSearchIndex, setActiveSearchIndex] = useState<number | null>(null)
   const [replaceActive, setReplaceActive] = useState(false)
   const [dragging, setDragging] = useState(false)
+  const dragDepth = useRef(0)
   const [notice, setNotice] = useState<{ text: string; error?: boolean } | null>(null)
   const [updateState, setUpdateState] = useState<UpdateState>({
     status: 'idle',
@@ -1061,6 +1062,7 @@ export function App(): JSX.Element {
   const onDrop = useCallback(
     (e: React.DragEvent) => {
       e.preventDefault()
+      dragDepth.current = 0
       setDragging(false)
       const paths = Array.from(e.dataTransfer.files)
         .map((file) => window.api.getDroppedPath(file))
@@ -1077,12 +1079,15 @@ export function App(): JSX.Element {
   return (
     <div
       className="app"
-      onDragOver={(e) => {
+      onDragEnter={(e) => {
         e.preventDefault()
+        dragDepth.current += 1
         setDragging(true)
       }}
-      onDragLeave={(e) => {
-        if (e.currentTarget === e.target) setDragging(false)
+      onDragOver={(e) => e.preventDefault()}
+      onDragLeave={() => {
+        dragDepth.current = Math.max(0, dragDepth.current - 1)
+        if (dragDepth.current === 0) setDragging(false)
       }}
       onDrop={onDrop}
     >

--- a/src/components/Welcome.tsx
+++ b/src/components/Welcome.tsx
@@ -23,7 +23,7 @@ export function Welcome({ onOpen, onNew, recentFiles, onOpenRecent, onForgetRece
   return (
     <div className="pane">
       <div className="welcome">
-        <img className="welcome__logo" src={logoMark} alt="Moji" />
+        <img className="welcome__logo" src={logoMark} alt="Moji" draggable={false} />
         <h1 className="welcome__title">{t('welcome.title')}</h1>
         <p className="welcome__tagline">{t('welcome.tagline')}</p>
         <div className="welcome__actions">


### PR DESCRIPTION
First off, really nice project — clean UI, fast, does exactly what a markdown editor should. Already planning to use it as my daily driver.

## Problem

Dragging a file over the window (or the app's own logo, which was
natively draggable) and leaving through a nested child element (e.g.
the top bar) instead of the `.app` container directly left the
"drop a .md file" overlay stuck on screen permanently.

## Cause

`onDragLeave` only cleared the `dragging` state when
`e.target === e.currentTarget`. Native `dragenter`/`dragleave` events
target whatever element is under the cursor, so leaving over any
child element never satisfied that check and the overlay never
closed.

## Fix

- Track drag depth with an enter/leave counter instead of comparing
  `target`/`currentTarget`, the standard pattern for nested
  drag-and-drop targets.
- Mark the welcome logo `<img>` as `draggable={false}`, since it was
  the easiest way to accidentally start a drag from inside the app.

## Testing

- `npm run typecheck`
- Manually reproduced the stuck overlay on `main`, confirmed it no
  longer happens after the fix (dragging the logo out, and dragging a
  file over the top bar and back out).