### PR TITLE
fix: use the preview typography in exported documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- Exported HTML, PDF, and PNG now use the preview's font family, size, and line height. Exports previously declared no font family at all and fell back to the browser's default serif at a different size.
+
 ## [0.1.3] - 2026-07-12
 
 ### Added

--- a/openspec/changes/fix-export-typography/.openspec.yaml
+++ b/openspec/changes/fix-export-typography/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/fix-export-typography/design.md
+++ b/openspec/changes/fix-export-typography/design.md
@@ -1,0 +1,55 @@
+## Context
+
+The preview and the export render the same Markdown HTML through different style pipelines. The preview lives inside the app shell, where `app.css` sets the base font on `body` and `Preview.tsx` layers the user's typography on `.markdown-body` as an inline style. The export builds a standalone document that inlines only `theme.css`, `markdown.css`, the KaTeX stylesheet, and a print block. `app.css` is deliberately excluded, since it styles the app chrome, not the document.
+
+The consequence went unnoticed because `theme.css` defines `--font-sans` but never applies it: the token is present in the exported document and referenced by nothing. The export therefore had no font declaration in any of its stylesheets, and Chromium fell back to its default serif.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- An exported document reads like the preview it came from: same family, size, and line height.
+- The export keeps working when the chosen family is unavailable.
+
+**Non-Goals:**
+
+- Inlining `app.css` into exports. It styles the app chrome and would leak unrelated rules into the document.
+- Embedding font binaries for the Inter web font. The existing Google Fonts link covers HTML export, and the generic families need no download.
+- Changing the rule that exports always render in the light theme.
+
+## Decisions
+
+### Give `.markdown-body` a base font in `markdown.css`
+
+The defect was possible because no stylesheet that travels with the document ever declared a font family: `app.css` owned it, and `app.css` is an app-chrome concern. `markdown.css` now declares `font-family: var(--font-sans)` alongside the `font-size` and `line-height` it already owned for `.markdown-body`, so the stylesheet is self-sufficient. Any consumer of it renders in a sans stack instead of the browser default serif.
+
+This is defense in depth, not the fix on its own: it guarantees a sane font, while the export rule below carries the user's actual choice. Without it, a future caller that skipped the typography argument would silently resurrect the original bug. The preview is unaffected, because `Preview.tsx` applies typography as an inline style, which outranks a class rule.
+
+### Pass typography explicitly rather than inlining `app.css`
+
+`buildStandaloneHtml` takes a required `typography` argument. Making it required means a future caller cannot silently reintroduce the fontless document; the type checker rejects it. Inlining `app.css` would have fixed the missing font by accident while importing chrome styling into the document.
+
+### Emit the rule on `.markdown-body`, not on `body`
+
+The preview applies typography to `.markdown-body`, so the export mirrors the same selector and inherits the same cascade relationship with `markdown.css`, whose `.markdown-body` rule sets the competing `font-size: 15px`. The generated rule is appended last, so equal specificity resolves in its favor.
+
+### Always append the `--font-sans` fallback stack
+
+The chosen family is emitted as `<family>, var(--font-sans)`. A missing Inter web font then degrades to the system stack instead of to a serif. When the user picks a generic family (`serif`, `monospace`, `system-ui`), that family wins and the fallback is inert.
+
+### Sanitize the family before interpolating it into CSS
+
+`previewFontFamily` is persisted as a free-form string and only checked with `typeof value === 'string'` in the settings IPC guard, so a hand-edited `settings.json` could inject arbitrary declarations into the generated `<style>`. The value is stripped to letters, digits, spaces, commas, quotes, and hyphens before interpolation, falling back to `Inter` when nothing survives. The preview path is not exposed to this, because React assigns through the CSSOM, which discards invalid values.
+
+## Risks / Trade-offs
+
+- [Inter is fetched from Google Fonts and may not resolve offline] → Pre-existing behavior, now with a real fallback: the export degrades to the system sans stack rather than to Times.
+- [`font-family: Inter, Inter, system-ui, ...` when the user picks Inter] → The token stack already starts with Inter, so the name repeats. Valid CSS and harmless; deduplicating would add a special case for no behavioral gain.
+
+## Migration Plan
+
+No persisted state changes. Existing exported files are unaffected; re-exporting produces the corrected document.
+
+## Open Questions
+
+None.

--- a/openspec/changes/fix-export-typography/proposal.md
+++ b/openspec/changes/fix-export-typography/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Exported documents do not use the font shown in the preview. The exported HTML computes to the browser's default serif (Times) at 15px, while the preview renders Inter at the user's chosen size. The `document-export` capability already requires HTML export to preserve the preview styling, so this is a defect against an existing requirement rather than a new feature.
+
+Two independent causes produce it:
+
+- The base font rule `body { font-family: var(--font-sans) }` lives in `app.css`, which `buildStandaloneHtml` does not inline. Neither `theme.css` nor `markdown.css` applies a font family to the document body, so the export declares no font at all.
+- `doExport` never passes the user's preview typography to `buildStandaloneHtml`, so the configured family, size, and line height are dropped even when a font is resolvable.
+
+## What Changes
+
+- Carry the preview typography (family, size, line height) into every export.
+- Declare a font family on `.markdown-body` in the exported document, with the shared `--font-sans` stack as fallback.
+- Apply to HTML, PDF, and PNG, which all share the same generated document.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `document-export`: Exported documents reproduce the preview typography.
+
+## Impact
+
+- Adds a required `typography` argument to `buildStandaloneHtml` in `src/lib/exportHtml.ts`.
+- Passes `settings` typography from `doExport` in `src/App.tsx`.
+- Does not change IPC contracts, export formats, or the light-theme rule for exports.

--- a/openspec/changes/fix-export-typography/specs/document-export/spec.md
+++ b/openspec/changes/fix-export-typography/specs/document-export/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Exports reproduce the preview typography
+The system SHALL render exported documents with the same font family, font size, and line height configured for the Markdown preview, and SHALL declare a font family in the exported document so it never falls back to the browser default serif. The requirement applies to HTML, PDF, and PNG, which share one generated document.
+
+#### Scenario: Export with the default typography
+- **WHEN** the user exports a document without having changed the preview typography
+- **THEN** the exported file renders in the default sans-serif family at the default size and line height, matching the preview
+
+#### Scenario: Export after changing the preview typography
+- **WHEN** the user selects a different preview font family, size, or line height in Settings and then exports
+- **THEN** the exported file renders with the selected family, size, and line height
+
+#### Scenario: Chosen font is unavailable
+- **WHEN** the exported document is opened where the configured font family cannot be resolved
+- **THEN** it falls back to the shared sans-serif stack rather than to the browser default serif
+
+#### Scenario: Code blocks keep their monospace font
+- **WHEN** an exported document contains fenced code
+- **THEN** the code keeps the monospace family, independent of the configured preview font

--- a/openspec/changes/fix-export-typography/tasks.md
+++ b/openspec/changes/fix-export-typography/tasks.md
@@ -1,0 +1,14 @@
+## 1. Carry typography into the export
+
+- [x] 1.1 Give `.markdown-body` a base `font-family` in `markdown.css`, so a rendered document never falls back to the browser default serif
+- [x] 1.2 Add a required `typography` argument to `buildStandaloneHtml` and emit a `.markdown-body` font rule with the `--font-sans` fallback
+- [x] 1.3 Sanitize the configured font family before interpolating it into the generated stylesheet
+- [x] 1.4 Pass the preview typography from `doExport` in `src/App.tsx`
+
+## 2. Verification
+
+- [x] 2.1 Run TypeScript typecheck
+- [x] 2.2 Confirm the generated document computes to the configured family, size, and line height, and that code blocks stay monospace
+- [x] 2.3 Confirm `markdown.css` alone no longer resolves to a serif, so the defect cannot return through another consumer
+- [x] 2.4 Export HTML from the running app and confirm it matches the preview
+- [ ] 2.5 Export PDF and PNG from the running app and confirm they match the preview

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -541,7 +541,11 @@ export function App(): JSX.Element {
       const rendered = renderMarkdown(s.activeDoc.content, { documentPath: s.activeDoc.path })
       const name = documentName(s.activeDoc, t('app.untitled'))
       // Exports (HTML/PDF/PNG) always use the light theme, regardless of the preview theme.
-      const doc = buildStandaloneHtml(rendered, 'light', name)
+      const doc = buildStandaloneHtml(rendered, 'light', name, {
+        fontFamily: settings.previewFontFamily,
+        fontSize: settings.previewFontSize,
+        lineHeight: settings.previewLineHeight
+      })
       const base = name.replace(/\.[^.]+$/, '')
       const res = await window.api.exportAs({
         format,
@@ -554,7 +558,7 @@ export function App(): JSX.Element {
       if (res.ok) flash(t('notice.exportSuccess', { path: res.path }))
       else if (!res.canceled) flash(t('notice.exportFailed', { error: res.error }), true)
     },
-    [flash, t]
+    [flash, settings.previewFontFamily, settings.previewFontSize, settings.previewLineHeight, t]
   )
 
   const confirmExport = useCallback(

--- a/src/lib/exportHtml.ts
+++ b/src/lib/exportHtml.ts
@@ -31,12 +31,45 @@ function escapeHtml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 }
 
+/** Preview typography, carried into the export so both render identically. */
+export interface ExportTypography {
+  fontFamily: string
+  fontSize: number
+  lineHeight: number
+}
+
+/** Keep a hand-edited settings.json from breaking out of the generated rule below. */
+function cssFontFamily(fontFamily: string): string {
+  const safe = fontFamily.replace(/[^A-Za-z0-9 ,'"-]/g, '').trim()
+  return safe || 'Inter'
+}
+
+/**
+ * The preview applies typography as an inline style on `.markdown-body`, and the base
+ * font lives in `app.css`, which is not inlined here. Without this rule the export has
+ * no font-family at all and falls back to the browser default serif.
+ */
+function typographyCss({ fontFamily, fontSize, lineHeight }: ExportTypography): string {
+  return `
+  .markdown-body {
+    font-family: ${cssFontFamily(fontFamily)}, var(--font-sans);
+    font-size: ${fontSize}px;
+    line-height: ${lineHeight};
+  }
+`
+}
+
 /**
  * Build a fully self-contained HTML document from rendered Markdown, with the
  * active theme's CSS inlined. Used for both HTML export and as the source for
  * PDF printing in the main process.
  */
-export function buildStandaloneHtml(renderedBody: string, theme: Theme, title: string): string {
+export function buildStandaloneHtml(
+  renderedBody: string,
+  theme: Theme,
+  title: string,
+  typography: ExportTypography
+): string {
   return `<!doctype html>
 <html data-md-theme="${theme}" lang="en">
 <head>
@@ -46,7 +79,7 @@ export function buildStandaloneHtml(renderedBody: string, theme: Theme, title: s
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400&display=swap" rel="stylesheet" />
 <title>${escapeHtml(title)}</title>
-<style>${katexCss}\n${themeCss}\n${markdownCss}\n${PRINT_CSS}</style>
+<style>${katexCss}\n${themeCss}\n${markdownCss}\n${PRINT_CSS}\n${typographyCss(typography)}</style>
 </head>
 <body>
 <article class="markdown-body">

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -3,6 +3,9 @@
   max-width: var(--reading-width);
   margin: 0 auto;
   padding: var(--space-6) var(--space-5);
+  /* Base font. In the app this is inherited from body, but exports do not inline app.css,
+     so without it here a rendered document falls back to the browser default serif. */
+  font-family: var(--font-sans);
   font-size: 15px;
   line-height: 1.7;
   color: var(--text);


### PR DESCRIPTION
## Problem

Exported documents do not use the font shown in the preview. The exported HTML computes to the browser default serif (Times) at 15px, while the preview renders Inter at the configured size.

It is not that the export picks a different font: the export declares **no font at all**.

Two independent causes stack up:

1. The base rule `body { font-family: var(--font-sans) }` lives in `app.css`, which `buildStandaloneHtml` does not inline (correctly so: `app.css` styles the app chrome, not the document). Neither `theme.css` nor `markdown.css` ever applied a font family to `.markdown-body`. `theme.css` does *define* the `--font-sans` token, so the token travels into the exported file and is referenced by nothing.
2. `doExport` called `buildStandaloneHtml(rendered, 'light', name)` without passing `settings`, so the configured family, size, and line height were dropped before they could reach the document.

The second cause is also why the size differed: the export fell back to the `markdown.css` default of 15px while the preview used the 16px from settings.

## Fix

**Base font in `markdown.css`.** `.markdown-body` now declares `font-family: var(--font-sans)` alongside the `font-size` and `line-height` it already owned. The stylesheet becomes self-sufficient: any document rendered with it has a font, so this class of defect cannot return through another consumer. The preview is unaffected, since `Preview.tsx` applies typography as an inline style, which outranks a class rule.

**Preview typography carried into the export.** `buildStandaloneHtml` emits a `.markdown-body` rule (the same selector the preview targets), with the `--font-sans` stack as fallback. The `typography` argument is required, so a future caller cannot silently drop it; the type checker rejects that.

**Sanitized family.** The configured family is stripped before being interpolated into the generated stylesheet. `previewFontFamily` is only validated as `typeof value === 'string'` by the settings IPC guard, so a hand-edited `settings.json` could otherwise inject declarations into the `<style>` block. The preview path is not exposed to this, since React assigns through the CSSOM, which discards invalid values.

Applies to HTML, PDF, and PNG, which all share the generated document.

## Testing

- `npm run typecheck`
- Reproduce on `main`: open any `.md`, export it as HTML, open the file in a browser. The body text is a serif (Times) at 15px, while the preview shows Inter at 16px.
- On this branch: export the same document. The body text now matches the preview.
- Change the font under Settings > Preview (`Inter`, `system-ui`, `serif`, `monospace`) and export again. The exported file follows the selection.
- Exercised HTML export from the running app and confirmed it matches the preview. PDF and PNG share the same generated document, but are still worth a manual look.

Measured with the real `buildStandaloneHtml` (bundled with esbuild, resolving the Vite-only `?inline` and `virtual:katex-fonts-css` imports the way `electron.vite.config.ts` does), reading computed style in a browser:

| | before | after |
|---|---|---|
| paragraph font | `Times` | `Inter, system-ui, ...` |
| paragraph size | 15px | 16px |
| line height | 25.5px | 27.2px |

Also confirmed that `theme.css` plus `markdown.css` alone, without the export rule, now resolve to the sans stack rather than to Times, which is what makes the base-font change worth having. Code blocks keep their monospace family.

## Cost

The generated rule is 84 bytes, emitted once per export, into a document that already carries 361 KB of inlined KaTeX font CSS. No runtime cost.

## Notes

Inter in the exported HTML depends on the Google Fonts `<link>`, and so on network access. That is not new: `src/index.html` loads Inter the same way, so the app itself has the same dependency. The difference is that an offline export now degrades to the system sans stack instead of to Times.

Out of scope, but worth recording: the export forces `max-width: 820px` while the preview uses `--reading-width` (760px, or fluid). So the export still does not match the preview in **width**.
