### PR TITLE
fix: export PNG of documents taller than the capture limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Exported HTML, PDF, and PNG now use the preview's font family, size, and line height. Exports previously declared no font family at all and fell back to the browser's default serif at a different size.
+- PNG export no longer fails on documents taller than roughly 8000 pixels. The capture exceeded Chromium's 16384-pixel texture limit and aborted with `UnknownVizError`; tall documents are now captured in slices and stitched into one image.
 
 ## [0.1.3] - 2026-07-12
 

--- a/electron/export.ts
+++ b/electron/export.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, dialog } from 'electron'
+import { BrowserWindow, dialog, nativeImage, screen } from 'electron'
 import { writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import {
@@ -153,6 +153,14 @@ async function htmlToPdf(
   }
 }
 
+/**
+ * Chromium composes a page capture into a single GPU texture, which tops out at 16384px.
+ * A capture taller than that fails outright with `UnknownVizError`, and a capture rect
+ * taller than the window is silently truncated. Tall documents are therefore captured in
+ * slices that stay under the cap and stitched back together.
+ */
+const MAX_CAPTURE_DEVICE_PX = 16384
+
 async function htmlToPng(
   html: string,
   pageSize: ExportPageSize,
@@ -166,11 +174,44 @@ async function htmlToPng(
     const documentHeight = (await win.webContents.executeJavaScript(
       'Math.ceil(Math.max(document.body.scrollHeight, document.documentElement.scrollHeight))'
     )) as number
-    const height = Math.max(size.height, documentHeight)
-    win.setContentSize(size.width, height)
+    const totalHeight = Math.max(size.height, documentHeight)
+
+    // The capture comes back in device pixels, so the usable slice shrinks as the display
+    // scale grows: 8192 CSS pixels on a 2x screen, 16384 on a 1x one.
+    const sliceHeight = Math.max(1, Math.floor(MAX_CAPTURE_DEVICE_PX / screen.getPrimaryDisplay().scaleFactor))
+
+    win.setContentSize(size.width, Math.min(totalHeight, sliceHeight))
     await new Promise((r) => setTimeout(r, 50))
-    const image = await win.webContents.capturePage({ x: 0, y: 0, width: size.width, height })
-    return image.toPNG()
+
+    const slices: Buffer[] = []
+    let deviceWidth = 0
+    let deviceHeight = 0
+
+    for (let top = 0; top < totalHeight; top += sliceHeight) {
+      const height = Math.min(sliceHeight, totalHeight - top)
+      // The page cannot scroll past `totalHeight - viewport`, so the final scrollTo is
+      // clamped. Capture from where the page actually landed, or the last slice repeats a
+      // band already captured.
+      const scrollY = (await win.webContents.executeJavaScript(
+        `window.scrollTo(0, ${top}); Math.round(window.scrollY)`
+      )) as number
+      await new Promise((r) => setTimeout(r, 50))
+
+      const image = await win.webContents.capturePage({
+        x: 0,
+        y: top - scrollY,
+        width: size.width,
+        height
+      })
+      const captured = image.getSize()
+      deviceWidth = captured.width
+      deviceHeight += captured.height
+      slices.push(image.toBitmap())
+    }
+
+    return nativeImage
+      .createFromBitmap(Buffer.concat(slices), { width: deviceWidth, height: deviceHeight, scaleFactor: 1 })
+      .toPNG()
   } finally {
     win.destroy()
   }

--- a/openspec/changes/fix-png-export-tall-documents/.openspec.yaml
+++ b/openspec/changes/fix-png-export-tall-documents/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/fix-png-export-tall-documents/design.md
+++ b/openspec/changes/fix-png-export-tall-documents/design.md
@@ -1,0 +1,65 @@
+## Context
+
+`htmlToPng` loaded the document into an offscreen window, grew the window to the full document height, and captured it in one `capturePage` call. That works only while the resulting image fits in one GPU texture.
+
+Measured on a 2x display, with A4 width:
+
+| document height | result |
+|---|---|
+| 8190 CSS px (16380 device px) | captured |
+| 8200 CSS px (16400 device px) | `UnknownVizError` |
+
+The cliff sits exactly on the 16384-pixel texture limit, in device pixels. PDF export survives because `printToPDF` never goes through the compositor.
+
+Two further facts constrain the fix:
+
+- A capture rectangle taller than the window is not rejected. It is silently cropped to the window height. Any approach that keeps a small window and asks for a tall rectangle produces a truncated image with no error.
+- A window taller than the texture cap is fine on its own. Only the capture rectangle must stay under the cap.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Export a PNG of any document height, with the full content and nothing repeated.
+- Keep short documents on exactly the behavior they have today.
+
+**Non-Goals:**
+
+- Changing PDF or HTML export.
+- Adding an image-processing dependency.
+- Paginating the PNG into multiple files.
+
+## Decisions
+
+### Slice the capture, stitch the raw bitmaps
+
+The document is captured in vertical slices, each at most `16384 / scaleFactor` CSS pixels tall. Slices come back as `nativeImage`s; `toBitmap()` exposes their raw pixel buffers, which concatenate directly because every slice shares one width. `nativeImage.createFromBitmap` turns the joined buffer back into an image to encode as PNG. No new dependency, and no re-encoding of intermediate images.
+
+A document shorter than one slice takes the single-slice path, which is byte-for-byte the old behavior.
+
+### Derive the slice height from the display scale factor
+
+The texture cap is in device pixels, so the usable CSS height halves on a 2x display: 8192 CSS pixels there, 16384 on a 1x display. Hardcoding a CSS-pixel slice height would either waste headroom on 1x displays or overflow on 3x ones.
+
+### Capture from where the page actually scrolled, not where it was asked to
+
+The page cannot scroll past `documentHeight - viewportHeight`, so the last `scrollTo` of a tall document is clamped. Capturing at rectangle origin 0 after a clamped scroll re-captures a band that the previous slice already covered: the stitched image then contains a duplicated stripe and is longer than the document.
+
+The scroll position actually reached is therefore read back, and the capture rectangle is offset by the difference. This was caught by exporting a black-to-white gradient and asserting that brightness rises monotonically down the stitched image; the first implementation produced a visible dip.
+
+### Hide scrollbars during capture
+
+The capture viewport is now shorter than the document, so the page scrolls and a scrollbar appears. macOS overlay scrollbars neither take layout width nor render into the capture, but the classic scrollbars on Windows and Linux do both: they would narrow the content and appear as a strip down the right edge of the image. `scrollbar-width: none` on the `export-png` root removes them, restoring the full-width layout the old full-height window produced.
+
+## Risks / Trade-offs
+
+- [Very tall documents allocate a large bitmap] → A 60000px document produces a 1588x120000 buffer of roughly 760 MB before encoding. It completes, but memory grows linearly with document height. Previously such a document simply failed, so this is strictly better; a height cap can be added if it proves to be a problem in practice.
+- [Each slice costs a scroll, a repaint wait, and a capture] → Export of a long document is slower than before. Documents under one slice are unaffected.
+
+## Migration Plan
+
+No persisted state, no contract change. The next PNG export of a tall document simply succeeds.
+
+## Open Questions
+
+None.

--- a/openspec/changes/fix-png-export-tall-documents/proposal.md
+++ b/openspec/changes/fix-png-export-tall-documents/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+PNG export fails for any document taller than roughly 8000 pixels, which is a very ordinary Markdown file. PDF and HTML export the same document without complaint.
+
+Chromium composes a page capture into a single GPU texture, capped at 16384 pixels. `capturePage` asked for the whole document in one rectangle, so the request aborted with `UnknownVizError` as soon as the document exceeded that cap. The cap is measured in device pixels, so on a 2x display the effective ceiling is only 8192 CSS pixels.
+
+Growing the window and capturing it in one shot cannot work: a capture rectangle taller than the window is silently truncated rather than rejected, so the naive workaround trades a visible error for a cropped image.
+
+## What Changes
+
+- Capture tall documents in vertical slices that stay under the texture cap, then stitch the slices into a single image.
+- Derive the slice height from the display scale factor, since the cap is in device pixels.
+- Hide scrollbars during PNG capture, which the now-shorter capture viewport would otherwise introduce.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `document-export`: PNG export supports documents of any height.
+
+## Impact
+
+- Rewrites `htmlToPng` in `electron/export.ts`; PDF and HTML paths are untouched.
+- Adds a scrollbar-hiding rule to the `export-png` styles in `src/lib/exportHtml.ts`.
+- Does not change IPC contracts, export formats, or the export dialog.

--- a/openspec/changes/fix-png-export-tall-documents/specs/document-export/spec.md
+++ b/openspec/changes/fix-png-export-tall-documents/specs/document-export/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: PNG export handles documents of any height
+The system SHALL export a PNG containing the whole document regardless of its rendered height, and SHALL NOT fail or silently crop when the document exceeds the platform's single-capture limit.
+
+#### Scenario: Export a document taller than the capture limit
+- **WHEN** the user exports a document whose rendered height exceeds what one screen capture can hold
+- **THEN** a PNG is written containing the entire document, top to bottom
+
+#### Scenario: Stitched image contains no repeated content
+- **WHEN** a tall document is captured in more than one pass
+- **THEN** the resulting image contains each band of the document exactly once, in order, and its height matches the rendered document
+
+#### Scenario: Export a short document
+- **WHEN** the user exports a document that fits within a single capture
+- **THEN** the PNG is produced as before, in one pass
+
+#### Scenario: Scrollbars stay out of the image
+- **WHEN** a tall document is captured on a platform with classic scrollbars
+- **THEN** no scrollbar appears in the exported image and the content keeps its full width

--- a/openspec/changes/fix-png-export-tall-documents/tasks.md
+++ b/openspec/changes/fix-png-export-tall-documents/tasks.md
@@ -1,0 +1,12 @@
+## 1. Slice and stitch the capture
+
+- [x] 1.1 Cap each capture at the device-pixel texture limit, deriving the slice height from the display scale factor
+- [x] 1.2 Read back the scroll position actually reached and offset the capture rectangle, so a clamped final scroll does not duplicate a band
+- [x] 1.3 Stitch the slice bitmaps into one image and encode it as PNG
+- [x] 1.4 Hide scrollbars during PNG capture
+
+## 2. Verification
+
+- [x] 2.1 Run TypeScript typecheck
+- [x] 2.2 Exercise the real `exportDocument` across document heights from 1500 to 60000 pixels, asserting exact image height and monotonic content (no duplicated slice)
+- [ ] 2.3 Export PNG from the running app for the document that originally failed

--- a/src/lib/exportHtml.ts
+++ b/src/lib/exportHtml.ts
@@ -12,6 +12,10 @@ const PRINT_CSS = `
     overflow-wrap: anywhere;
   }
   html.export-png pre code { white-space: inherit; }
+  /* PNG capture scrolls a viewport shorter than the document. Classic scrollbars (Windows,
+     Linux) would take layout width and land in the image; macOS overlay ones would not. */
+  html.export-png { scrollbar-width: none; }
+  html.export-png::-webkit-scrollbar { display: none; }
   @page { margin: 16mm; }
   @media print {
     a { color: inherit; text-decoration: underline; }


### PR DESCRIPTION
## Problem

PNG export fails for any document taller than roughly 8000 pixels, which is a very ordinary Markdown file. The bundled Markdown guide renders at 12197px and is enough to trigger it. PDF and HTML export the same document without complaint.

## Cause

Chromium composes a page capture into a single GPU texture, capped at **16384 pixels**. `capturePage` asked for the whole document in one rectangle, so the call aborted with `UnknownVizError` as soon as the document exceeded that cap.

The cap is in **device** pixels, so the ceiling depends on display scale. Measured on a 2x display, at A4 width:

| document height | result |
|---|---|
| 8190 CSS px (16380 device px) | captured |
| 8200 CSS px (16400 device px) | `UnknownVizError` |

PDF survives because `printToPDF` never goes through the compositor.

Two further facts shaped the fix:

- **A capture rectangle taller than the window is not rejected, it is silently cropped** to the window height. So simply keeping a small window and asking for a tall rectangle trades a visible error for a truncated image with no warning.
- A window taller than the cap is fine on its own. Only the capture rectangle must stay under it.

## Fix

Capture the document in vertical slices that stay under the cap, then stitch them back together.

- The slice height is derived from the display scale factor, since the cap is in device pixels: 8192 CSS px on a 2x display, 16384 on a 1x one.
- Slices come back as `nativeImage`s; `toBitmap()` exposes their raw pixel buffers, which concatenate directly because every slice shares one width. `nativeImage.createFromBitmap` turns the joined buffer back into an image to encode. No new dependency, and no re-encoding of intermediate images.
- A document that fits in one slice takes the single-slice path, which is the old behavior.

Two subtleties, both caught by asserting on pixels rather than trusting the output height:

**The last slice repeated a band.** A page cannot scroll past `documentHeight - viewport`, so the final `scrollTo` is clamped. Capturing at rectangle origin 0 after a clamped scroll re-captures content the previous slice already covered. The fix reads back the scroll position actually reached and offsets the capture rectangle by the difference. Exporting a black-to-white gradient and asserting that brightness rises monotonically down the stitched image exposed this; the first implementation had a visible dip.

**Scrollbars would have entered the image.** The capture viewport is now shorter than the document, so the page scrolls. macOS overlay scrollbars neither take layout width nor render into a capture, but the classic scrollbars on Windows and Linux do both: they would narrow the content and appear as a strip down the right edge. `scrollbar-width: none` on the `export-png` root removes them and restores the full-width layout the old full-height window produced.

## Testing

- `npm run typecheck`
- **Reproducing on `main` depends on your display scale.** The cap is 16384 device pixels, so:
  - On a **2x display** (any Retina Mac): open the bundled Markdown guide from the status bar and export it as PNG. It renders at 12197px, over the 8192 CSS px ceiling, and fails with `UnknownVizError`.
  - On a **1x display** (most Windows and Linux setups): the ceiling is 16384 CSS px, so the guide fits in one capture and exports fine. You need a longer document to see the bug; concatenating the guide with itself is enough.
- On this branch, the same export succeeds and the image contains the whole document.
- Exercised the real `exportDocument` (with the save dialog stubbed) across document heights of 1500, 8000, 8300, 12000, 30000 and 60000 pixels. Every one produced a PNG of exactly the expected height, with monotonic gradient content, meaning no slice was dropped, repeated, or misaligned. 8300px is the regime that fails on `main`.
- Short documents still export in a single pass.

## Trade-offs

A very tall document now allocates a large bitmap: a 60000px document produces a 1588x120000 buffer of roughly 760 MB before encoding, and memory grows linearly with height. It completes, and previously such a document simply failed, so this is strictly better. A height cap can be added if it ever becomes a problem in practice.

Each slice costs a scroll, a repaint wait, and a capture, so exporting a long document is slower than before. Documents under one slice are unaffected.
