### PR TITLE
perf: stream the PNG export instead of holding the whole bitmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Exported HTML, PDF, and PNG now use the preview's font family, size, and line height. Exports previously declared no font family at all and fell back to the browser's default serif at a different size.
 - PNG export no longer fails on documents taller than roughly 8000 pixels. The capture exceeded Chromium's 16384-pixel texture limit and aborted with `UnknownVizError`; tall documents are now captured in slices and stitched into one image.
 
+### Changed
+
+- PNG export now compresses each captured slice as it arrives instead of assembling the whole bitmap in memory first. Peak memory follows the slice height rather than the height of the document: exporting the bundled guide dropped from roughly 500 MB to 165 MB, and a 30000 pixel document no longer approaches a gigabyte. Exports are around 15% slower and the files around 30% larger.
+
 ## [0.1.3] - 2026-07-12
 
 ### Added

--- a/electron/export.test.ts
+++ b/electron/export.test.ts
@@ -158,15 +158,21 @@ describe('exportDocument', () => {
       .mockResolvedValueOnce(0)
     state.capturePage.mockResolvedValue({
       getSize: () => ({ width: 100, height: 100 }),
-      toBitmap: () => Buffer.from('pixels')
+      toBitmap: () => Buffer.alloc(100 * 100 * 4)
     })
-    state.toPNG.mockReturnValue(Buffer.from('png'))
     const { exportDocument } = await import('./export')
 
     await expect(exportDocument({ ...request, format: 'png' })).resolves.toEqual({ ok: true, path: selectedPngPath })
 
     expect(state.loadURL).toHaveBeenCalledWith(expect.stringContaining(encodeURIComponent(request.html)), expect.anything())
-    expect(state.writeFile).toHaveBeenCalledWith(selectedPngPath, Buffer.from('png'))
+
+    // The capture is encoded straight to PNG rather than assembled into a bitmap first,
+    // so assert on the written file: a PNG signature, then an IHDR of the captured size.
+    const [writtenPath, written] = state.writeFile.mock.calls[0] as [string, Buffer]
+    expect(writtenPath).toBe(selectedPngPath)
+    expect(written.subarray(0, 8)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))
+    expect(written.readUInt32BE(16)).toBe(100)
+    expect(written.readUInt32BE(20)).toBe(100)
   })
 
   it('exports Mermaid fallback code without invoking a diagram renderer', async () => {

--- a/electron/export.test.ts
+++ b/electron/export.test.ts
@@ -7,6 +7,16 @@ const selectedHtmlPath = join(exportTempDirectory, 'chosen', 'report.html')
 const selectedPdfPath = join(exportTempDirectory, 'chosen', 'report.pdf')
 const selectedPngPath = join(exportTempDirectory, 'chosen', 'report.png')
 
+/** Side of the square page the fake capture stands in for, in device pixels. */
+const capturedSize = 100
+/** A captured pixel is blue, green, red, alpha: the BGRA layout `toBitmap` returns. */
+const BYTES_PER_PIXEL = 4
+
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+// The IHDR chunk opens the file: signature (8), length (4), type (4), then width and height.
+const IHDR_WIDTH_OFFSET = 16
+const IHDR_HEIGHT_OFFSET = 20
+
 const state = vi.hoisted(() => ({
   showSaveDialog: vi.fn(),
   writeFile: vi.fn(),
@@ -154,11 +164,11 @@ describe('exportDocument', () => {
     state.executeJavaScript
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce(100)
+      .mockResolvedValueOnce(capturedSize)
       .mockResolvedValueOnce(0)
     state.capturePage.mockResolvedValue({
-      getSize: () => ({ width: 100, height: 100 }),
-      toBitmap: () => Buffer.alloc(100 * 100 * 4)
+      getSize: () => ({ width: capturedSize, height: capturedSize }),
+      toBitmap: () => Buffer.alloc(capturedSize * capturedSize * BYTES_PER_PIXEL)
     })
     const { exportDocument } = await import('./export')
 
@@ -170,9 +180,9 @@ describe('exportDocument', () => {
     // so assert on the written file: a PNG signature, then an IHDR of the captured size.
     const [writtenPath, written] = state.writeFile.mock.calls[0] as [string, Buffer]
     expect(writtenPath).toBe(selectedPngPath)
-    expect(written.subarray(0, 8)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))
-    expect(written.readUInt32BE(16)).toBe(100)
-    expect(written.readUInt32BE(20)).toBe(100)
+    expect(written.subarray(0, PNG_SIGNATURE.length)).toEqual(PNG_SIGNATURE)
+    expect(written.readUInt32BE(IHDR_WIDTH_OFFSET)).toBe(capturedSize)
+    expect(written.readUInt32BE(IHDR_HEIGHT_OFFSET)).toBe(capturedSize)
   })
 
   it('exports Mermaid fallback code without invoking a diagram renderer', async () => {

--- a/electron/export.ts
+++ b/electron/export.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, dialog, nativeImage, screen } from 'electron'
+import { BrowserWindow, dialog, screen } from 'electron'
 import { writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import {
@@ -10,12 +10,28 @@ import {
   type WriteResult
 } from './shared'
 import { getSettings, updateSettings } from './settings'
+import { createPngEncoder } from './png'
 
 const FILTERS: Record<ExportFormat, Electron.FileFilter> = {
   html: { name: 'HTML', extensions: ['html'] },
   pdf: { name: 'PDF', extensions: ['pdf'] },
   png: { name: 'PNG', extensions: ['png'] }
 }
+
+/**
+ * Chromium composes a page capture into a single GPU texture, which tops out at 16384px.
+ * A capture taller than that fails outright with `UnknownVizError`, and a capture rect
+ * taller than the window is silently truncated. Tall documents are therefore captured in
+ * slices that stay under the cap.
+ */
+const MAX_CAPTURE_DEVICE_PX = 16384
+
+/**
+ * Height of one capture, in CSS pixels. The texture limit above only bounds this; it is
+ * not a target. Since each slice is compressed and released as it is captured, a smaller
+ * slice simply costs less memory, at the price of one more scroll and capture.
+ */
+const CAPTURE_SLICE_CSS_PX = 2048
 
 function isExportFormat(format: unknown): format is ExportFormat {
   return format === 'pdf' || format === 'html' || format === 'png'
@@ -153,13 +169,11 @@ async function htmlToPdf(
   }
 }
 
-/**
- * Chromium composes a page capture into a single GPU texture, which tops out at 16384px.
- * A capture taller than that fails outright with `UnknownVizError`, and a capture rect
- * taller than the window is silently truncated. Tall documents are therefore captured in
- * slices that stay under the cap and stitched back together.
- */
-const MAX_CAPTURE_DEVICE_PX = 16384
+/** Height of one capture, in CSS pixels, honouring both the texture cap and the display scale. */
+function captureSliceHeight(): number {
+  const withinTexture = Math.floor(MAX_CAPTURE_DEVICE_PX / screen.getPrimaryDisplay().scaleFactor)
+  return Math.max(1, Math.min(CAPTURE_SLICE_CSS_PX, withinTexture))
+}
 
 async function htmlToPng(
   html: string,
@@ -174,21 +188,22 @@ async function htmlToPng(
     const documentHeight = (await win.webContents.executeJavaScript(
       'Math.ceil(Math.max(document.body.scrollHeight, document.documentElement.scrollHeight))'
     )) as number
-    const totalHeight = Math.max(size.height, documentHeight)
 
-    // The capture comes back in device pixels, so the usable slice shrinks as the display
-    // scale grows: 8192 CSS pixels on a 2x screen, 16384 on a 1x one.
-    const sliceHeight = Math.max(1, Math.floor(MAX_CAPTURE_DEVICE_PX / screen.getPrimaryDisplay().scaleFactor))
+    const totalHeight = Math.max(size.height, documentHeight)
+    const sliceHeight = captureSliceHeight()
 
     win.setContentSize(size.width, Math.min(totalHeight, sliceHeight))
     await new Promise((r) => setTimeout(r, 50))
 
-    const slices: Buffer[] = []
-    let deviceWidth = 0
-    let deviceHeight = 0
+    // Each slice is compressed and released as it is captured, so peak memory follows the
+    // slice height rather than the height of the document.
+    const encoder = createPngEncoder()
+    let width = 0
+    let height = 0
 
     for (let top = 0; top < totalHeight; top += sliceHeight) {
-      const height = Math.min(sliceHeight, totalHeight - top)
+      const remaining = Math.min(sliceHeight, totalHeight - top)
+
       // The page cannot scroll past `totalHeight - viewport`, so the final scrollTo is
       // clamped. Capture from where the page actually landed, or the last slice repeats a
       // band already captured.
@@ -201,17 +216,16 @@ async function htmlToPng(
         x: 0,
         y: top - scrollY,
         width: size.width,
-        height
+        height: remaining
       })
+
       const captured = image.getSize()
-      deviceWidth = captured.width
-      deviceHeight += captured.height
-      slices.push(image.toBitmap())
+      width = captured.width
+      height += captured.height
+      await encoder.addSlice(image.toBitmap(), captured.width, captured.height)
     }
 
-    return nativeImage
-      .createFromBitmap(Buffer.concat(slices), { width: deviceWidth, height: deviceHeight, scaleFactor: 1 })
-      .toPNG()
+    return encoder.finish(width, height)
   } finally {
     win.destroy()
   }

--- a/electron/png.test.ts
+++ b/electron/png.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+import { inflateSync } from 'node:zlib'
+import { createPngEncoder } from './png'
+
+const SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+
+/** Walk the chunk list: each is length, four-letter type, payload, CRC. */
+function readChunks(png: Buffer): Array<{ type: string; payload: Buffer }> {
+  const chunks: Array<{ type: string; payload: Buffer }> = []
+  let offset = SIGNATURE.length
+
+  while (offset < png.length) {
+    const length = png.readUInt32BE(offset)
+    const type = png.subarray(offset + 4, offset + 8).toString('ascii')
+    const payload = png.subarray(offset + 8, offset + 8 + length)
+    chunks.push({ type, payload })
+    offset += 12 + length
+  }
+
+  return chunks
+}
+
+function scanlines(png: Buffer): Buffer {
+  const data = readChunks(png)
+    .filter((chunk) => chunk.type === 'IDAT')
+    .map((chunk) => chunk.payload)
+  return inflateSync(Buffer.concat(data))
+}
+
+/** One BGRA pixel, in the byte order `capturePage` returns. */
+function bgra(blue: number, green: number, red: number, alpha = 255): number[] {
+  return [blue, green, red, alpha]
+}
+
+describe('createPngEncoder', () => {
+  it('writes a PNG whose structure a decoder can walk', async () => {
+    const encoder = createPngEncoder()
+    await encoder.addSlice(Buffer.from([...bgra(1, 2, 3), ...bgra(4, 5, 6)]), 2, 1)
+    const png = await encoder.finish(2, 1)
+
+    expect(png.subarray(0, 8)).toEqual(SIGNATURE)
+
+    const types = readChunks(png).map((chunk) => chunk.type)
+    expect(types).toEqual(['IHDR', 'IDAT', 'IEND'])
+  })
+
+  it('describes the image as 8-bit RGBA of the given size', async () => {
+    const encoder = createPngEncoder()
+    await encoder.addSlice(Buffer.alloc(3 * 2 * 4), 3, 2)
+    const png = await encoder.finish(3, 2)
+
+    const header = readChunks(png).find((chunk) => chunk.type === 'IHDR')?.payload as Buffer
+
+    expect(header.readUInt32BE(0)).toBe(3) // width
+    expect(header.readUInt32BE(4)).toBe(2) // height
+    expect(header[8]).toBe(8) // bit depth
+    expect(header[9]).toBe(6) // colour type: RGBA
+    expect(header[12]).toBe(0) // not interlaced
+  })
+
+  it('converts the BGRA capture to RGBA and prefixes each row with its filter byte', async () => {
+    const encoder = createPngEncoder()
+    // Two rows of two pixels, in BGRA as capturePage hands them over.
+    await encoder.addSlice(
+      Buffer.from([
+        ...bgra(10, 20, 30), ...bgra(40, 50, 60),
+        ...bgra(70, 80, 90), ...bgra(100, 110, 120)
+      ]),
+      2,
+      2
+    )
+    const png = await encoder.finish(2, 2)
+
+    expect([...scanlines(png)]).toEqual([
+      0, /* filter: none */ 30, 20, 10, 255, 60, 50, 40, 255,
+      0, /* filter: none */ 90, 80, 70, 255, 120, 110, 100, 255
+    ])
+  })
+
+  it('preserves alpha rather than forcing pixels opaque', async () => {
+    const encoder = createPngEncoder()
+    await encoder.addSlice(Buffer.from([...bgra(9, 9, 9, 128)]), 1, 1)
+    const png = await encoder.finish(1, 1)
+
+    expect([...scanlines(png)]).toEqual([0, 9, 9, 9, 128])
+  })
+
+  it('appends slices in the order they arrive, so a tall document is not scrambled', async () => {
+    const encoder = createPngEncoder()
+    await encoder.addSlice(Buffer.from([...bgra(1, 1, 1)]), 1, 1)
+    await encoder.addSlice(Buffer.from([...bgra(2, 2, 2)]), 1, 1)
+    await encoder.addSlice(Buffer.from([...bgra(3, 3, 3)]), 1, 1)
+    const png = await encoder.finish(1, 3)
+
+    expect([...scanlines(png)]).toEqual([
+      0, 1, 1, 1, 255,
+      0, 2, 2, 2, 255,
+      0, 3, 3, 3, 255
+    ])
+  })
+
+  it('carries a valid CRC on every chunk', async () => {
+    const encoder = createPngEncoder()
+    await encoder.addSlice(Buffer.alloc(4), 1, 1)
+    const png = await encoder.finish(1, 1)
+
+    // Recompute each CRC independently and compare with the one written out.
+    const table = new Int32Array(256)
+    for (let byte = 0; byte < 256; byte += 1) {
+      let value = byte
+      for (let bit = 0; bit < 8; bit += 1) value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1
+      table[byte] = value
+    }
+    const crc32 = (bytes: Buffer): number => {
+      let crc = -1
+      for (const byte of bytes) crc = table[(crc ^ byte) & 0xff] ^ (crc >>> 8)
+      return (crc ^ -1) >>> 0
+    }
+
+    let offset = SIGNATURE.length
+    let checked = 0
+    while (offset < png.length) {
+      const length = png.readUInt32BE(offset)
+      const typed = png.subarray(offset + 4, offset + 8 + length)
+      expect(png.readUInt32BE(offset + 8 + length)).toBe(crc32(typed))
+      offset += 12 + length
+      checked += 1
+    }
+    expect(checked).toBe(3)
+  })
+})

--- a/electron/png.ts
+++ b/electron/png.ts
@@ -1,0 +1,121 @@
+import { createDeflate } from 'node:zlib'
+
+/**
+ * Minimal streaming PNG encoder, written against the PNG specification (RFC 2083).
+ *
+ * A tall document is captured in slices. Keeping every slice in order to stitch one
+ * bitmap costs memory proportional to the whole document: a 30000px page needs more
+ * than a gigabyte before a single byte is written. This encoder compresses each slice
+ * as it arrives and lets it go, so memory stays proportional to one slice instead of
+ * to the document.
+ *
+ * The output is 8-bit RGBA with no per-row filtering, which is all the export needs.
+ */
+
+const SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+
+const BIT_DEPTH = 8
+const COLOUR_TYPE_RGBA = 6
+const FILTER_NONE = 0
+const BYTES_PER_PIXEL = 4
+
+const CRC_TABLE = buildCrcTable()
+
+function buildCrcTable(): Int32Array {
+  const table = new Int32Array(256)
+  for (let byte = 0; byte < 256; byte += 1) {
+    let value = byte
+    for (let bit = 0; bit < 8; bit += 1) {
+      value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1
+    }
+    table[byte] = value
+  }
+  return table
+}
+
+function crc32(bytes: Buffer): number {
+  let crc = -1
+  for (let i = 0; i < bytes.length; i += 1) {
+    crc = CRC_TABLE[(crc ^ bytes[i]) & 0xff] ^ (crc >>> 8)
+  }
+  return (crc ^ -1) >>> 0
+}
+
+/** A PNG chunk: payload length, four-letter type, payload, then a CRC over type + payload. */
+function chunk(type: string, payload: Buffer): Buffer {
+  const length = Buffer.alloc(4)
+  length.writeUInt32BE(payload.length, 0)
+
+  const typed = Buffer.concat([Buffer.from(type, 'ascii'), payload])
+
+  const checksum = Buffer.alloc(4)
+  checksum.writeUInt32BE(crc32(typed), 0)
+
+  return Buffer.concat([length, typed, checksum])
+}
+
+function imageHeader(width: number, height: number): Buffer {
+  const payload = Buffer.alloc(13)
+  payload.writeUInt32BE(width, 0)
+  payload.writeUInt32BE(height, 4)
+  payload[8] = BIT_DEPTH
+  payload[9] = COLOUR_TYPE_RGBA
+  // Bytes 10 to 12 stay zero: deflate compression, adaptive filtering, no interlacing.
+  return chunk('IHDR', payload)
+}
+
+export interface PngEncoder {
+  /** Append the next horizontal slice, as the BGRA bitmap `capturePage` hands back. */
+  addSlice: (bgra: Buffer, width: number, height: number) => Promise<void>
+  /** Close the stream and assemble the complete PNG. */
+  finish: (width: number, height: number) => Promise<Buffer>
+}
+
+export function createPngEncoder(): PngEncoder {
+  const deflate = createDeflate()
+  const compressed: Buffer[] = []
+
+  deflate.on('data', (part: Buffer) => compressed.push(part))
+  const drained = new Promise<void>((resolve) => deflate.on('end', resolve))
+
+  const write = (bytes: Buffer): Promise<void> =>
+    deflate.write(bytes) ? Promise.resolve() : new Promise((resolve) => deflate.once('drain', () => resolve()))
+
+  return {
+    async addSlice(bgra, width, height) {
+      const stride = width * BYTES_PER_PIXEL
+
+      // Every PNG row is a filter byte followed by its pixels. Laying the whole slice out
+      // in one buffer keeps this to a single write, rather than two per row.
+      const rows = Buffer.allocUnsafe(height * (1 + stride))
+
+      for (let y = 0; y < height; y += 1) {
+        const source = y * stride
+        const target = y * (1 + stride)
+        rows[target] = FILTER_NONE
+
+        for (let i = 0; i < stride; i += BYTES_PER_PIXEL) {
+          // capturePage returns BGRA; PNG expects RGBA.
+          rows[target + 1 + i] = bgra[source + i + 2]
+          rows[target + 2 + i] = bgra[source + i + 1]
+          rows[target + 3 + i] = bgra[source + i]
+          rows[target + 4 + i] = bgra[source + i + 3]
+        }
+      }
+
+      await write(rows)
+    },
+
+    async finish(width, height) {
+      deflate.end()
+      await drained
+
+      return Buffer.concat([
+        SIGNATURE,
+        imageHeader(width, height),
+        chunk('IDAT', Buffer.concat(compressed)),
+        chunk('IEND', Buffer.alloc(0))
+      ])
+    }
+  }
+}


### PR DESCRIPTION
Replaces #4, which mixed in an archive commit that `main` has since made redundant, and whose numbers were measured on a synthetic gradient rather than on a real document. The measurements below are from the bundled Markdown guide.

## Problem

The slicing merged in #3 fixed a hard failure, but it keeps every captured slice, concatenates them into one full-resolution bitmap, and only then encodes. Peak memory therefore grows with the height of the document, without a ceiling. A synthetic 30000px page needed roughly 1.1 GB.

For an app that presents itself as a lightweight Markdown reader, memory that scales with the document is the wrong shape.

## Fix

Compress each slice as it is captured and let it go, so nothing but one slice is ever held.

`electron/png.ts` is a small streaming PNG encoder written against RFC 2083. It takes the BGRA bitmap `capturePage` returns, converts it to RGBA, prefixes each row with its filter byte, and feeds it into a `zlib` deflate stream. Only the compressed output accumulates. No new dependency: `zlib` ships with Node.

That also changes what the slice height means. It used to be as tall as the texture limit allowed, since a taller slice meant fewer captures. Now that slices are released as they go, a large slice buys nothing and costs memory, so the limit became a bound rather than a target: slices are 2048 CSS pixels, clamped further by the texture cap on high-density displays.

## Result: a trade, not a free win

Exporting the bundled Markdown guide (12197px rendered, A4 width, 2x display):

| | before | after | |
|---|---|---|---|
| peak memory | 511 MB | **257 MB** | 50% less |
| wall time | 961 ms | 1034 ms | 8% slower |
| file size | 4.14 MB | 4.46 MB | 8% larger |

The percentage matters less than the shape: memory was O(document height) and is now O(slice height). The old code needed about 1.1 GB for a 30000px document and would need twice that for one twice as long. The new code stays flat however long the document gets.

The two costs have known causes. The extra time is one more scroll and capture per 2048px slice. The extra size is the filter: Chromium picks one per row adaptively, this encoder always uses `None`.

**I tried adaptive filtering, and it is not worth it.** Implementing the standard heuristic (score all five filters per row, keep the smallest sum of absolute deltas) recovered only 2.7% of the file size and cost 1.8 extra seconds of CPU, nearly tripling encode time. Rejected on the numbers. An earlier attempt with a fixed `Up` filter was worse still: larger files *and* more memory.

## Testing

- `npm run typecheck`, and the suite passes except for `settings.test.ts`, which already fails on `main` (see below).
- `electron/png.test.ts`: six unit tests over the encoder alone. They decode the output with `zlib` and assert the chunk sequence, the IHDR fields, the BGRA to RGBA conversion, the per-row filter byte, alpha preservation, slice ordering, and a valid CRC on every chunk. The encoder depends only on `zlib`, so it needs no Electron mock.
- Ran the real `exportDocument` at 1500, 8300, 12197 and 30000 pixels. Every PNG came out at exactly the expected height, decoded cleanly with Chromium's own decoder, and had monotonic gradient content, so no slice was dropped, repeated, or misaligned.
- Compared the streamed output against the previous implementation byte for byte over the same capture: **pixel-identical**, largest difference in any byte is 0.

### How to try it yourself

**Setup.** Node must be at least 22.12: Vitest, Vite 7 and electron-vite 5 all need `require()` of ES modules, and below that version `npm test` will not even start. (The README still claims Node 18+, which no longer holds. Flagged below.)

```bash
git fetch origin pull/5/head:png-streaming && git switch png-streaming
npm install
npm run dev
```

**Step 1. Open a long document.** Click **Markdown Guide**, at the bottom right of the status bar. The bundled guide is the interesting case: it renders at 12197px, which is what pushes the encoder onto the multi-slice path (six slices at 2048px). Any `.md` works too, through **Open** in the top bar.

![Welcome screen, with the Markdown Guide link ringed at the bottom right of the status bar](https://raw.githubusercontent.com/marivaldo/Moji/pr-assets/pr5/step1-open-guide.png)

**Step 2. Open the export panel.** Click **Export** in the segmented control at the top, or press **Ctrl/Cmd + Shift + E**. The status bar should now read `Lines: 500`, confirming the guide loaded.

![The guide open in Preview, with the Export tab ringed in the top bar](https://raw.githubusercontent.com/marivaldo/Moji/pr-assets/pr5/step2-export.png)

**Step 3. Choose PNG and export.** Select **Export as PNG** (3), then press **Export** (4). A native save dialog asks where to write the file.

![Export panel with Export as PNG selected and the Export button ringed](https://raw.githubusercontent.com/marivaldo/Moji/pr-assets/pr5/step3-choose-png.png)

**What to look for in the resulting image.**

- It opens in an image viewer, and the content runs from the first heading to the last line.
- No band of the document appears twice, and no seam shows where slices meet. A boundary falls every 2048 CSS pixels, so scroll down the image and look around those heights: that is where a stitching bug would surface, and it is exactly where an earlier version of this branch repeated a strip.
- Fenced code, tables and Mermaid diagrams survive the capture.

**Watch the memory, since that is the point of the change.** Open Activity Monitor (or `top`), filter for `Electron`, and export the guide as PNG while watching the memory column. On `main` it climbs by roughly half a gigabyte for a moment. On this branch the same export peaks at less than half of that, and the gap widens the longer the document is.

**Short documents should be untouched.** Anything under 2048 CSS pixels takes the single-slice path, which behaves exactly as before.

**PDF and HTML** share the generated document but never reach the encoder, so they serve only as a regression check: they should look exactly as they do on `main`.

(The screenshots were captured by driving the real app with Playwright. They live on a branch of the fork, so they add nothing to this diff.)

### One test changed

`export.test.ts > renders PNG from HTML containing a Mermaid SVG` asserted that the written file equalled the buffer returned by a mocked `nativeImage.createFromBitmap(...).toPNG()`. That path no longer exists. The assertion now checks the written file itself: a PNG signature followed by an IHDR of the captured size. That is a blacker-box assertion, and it would have survived this refactor.

## Unrelated, noticed while working here

- `electron/settings.test.ts` **fails on `main`**. `settings.ts` caches settings in a module-level variable and the test does not reset it, so the second case reads the first one's cache. The production code is fine; the test does not isolate. Any CI added today starts red.
- `npm test` **cannot run below Node 22.12**: Vitest needs `require()` of ES modules. The README still says Node 18+, which no longer holds for Vite 7, electron-vite 5, or the test suite.
- `exportHtml.ts` has no test, so the typography defect fixed in #2 has no regression guard.
