### PR TITLE
feat: add macOS support

### DIFF
--- a/.ai-framework/RULES.md
+++ b/.ai-framework/RULES.md
@@ -17,7 +17,7 @@ Projeto atual: Moji, aplicativo desktop Electron + React + TypeScript para abrir
 
 ### Main Process (`electron/`)
 
-- `main.ts`: janela (`BrowserWindow` 1000x760, min 640x480), single-instance lock com forward de argumentos de arquivo, handlers IPC, abertura via dialogo nativo, CLI (`process.argv`), evento `open-file` (macOS/Linux) e drag-drop (via `webUtils.getPathForFile`).
+- `main.ts`: janela (`BrowserWindow` 1000x760, min 640x480), single-instance lock com forward de argumentos de arquivo, handlers IPC, abertura via dialogo nativo, CLI (`process.argv`), evento `open-file` (macOS/Linux), drag-drop (via `webUtils.getPathForFile`) e menu de aplicacao (apenas no macOS; Windows e Linux ficam sem menu).
 - `preload.ts`: expoe API segura ao renderer via `contextBridge` com tipagem completa (`RendererApi`).
 - `shared.ts`: tipos e constantes compartilhados entre main, preload e renderer (tipos de resultado IPC, `Settings`, `ExportFormat`, `SUPPORTED_LANGUAGES`, `IPC` channels).
 - `settings.ts`: persiste configuracoes do usuario em `settings.json` no `userData`; resolve idioma inicial a partir do locale do SO; aplica limites numericos (`boundedNumber`).
@@ -46,8 +46,9 @@ Projeto atual: Moji, aplicativo desktop Electron + React + TypeScript para abrir
 - Editor baseado em CodeMirror 6 (`@codemirror/commands`, `@codemirror/lang-markdown`, `@codemirror/search`).
 - Internacionalizacao com `i18next` + `react-i18next`.
 - Build/desenvolvimento com `electron-vite`.
-- Empacotamento com `electron-builder` (NSIS para Windows, AppImage/deb para Linux).
-- Atualizacao automatica com `electron-updater` e metadados publicados em GitHub Releases.
+- Empacotamento com `electron-builder` (NSIS para Windows, AppImage/deb para Linux, DMG/ZIP universal para macOS).
+- Atualizacao automatica com `electron-updater` e metadados publicados em GitHub Releases. Indisponivel no macOS: builds nao assinados nao podem se auto-atualizar.
+- Node exigido: `^20.19.0 || >=22.12.0` (Vite 7 / electron-vite 5, e `require()` de ESM no empacotamento). Declarado em `engines` no `package.json`.
 
 ### Formatos de exportacao suportados
 
@@ -66,6 +67,8 @@ Projeto atual: Moji, aplicativo desktop Electron + React + TypeScript para abrir
 - Abrir links externos no navegador do sistema (`shell.openExternal`), nao dentro do app.
 - Tratar arquivos suportados como `.md` e `.markdown`.
 - Proteger fechamento de documento/app quando houver alteracoes nao salvas (fluxo `requestClose` -> `confirmClose` -> `forceQuit`).
+- Distinguir fechar janela de encerrar app: no macOS a janela fechada nao encerra o processo. Toda saida (Cmd+Q, Quit do Dock, `before-quit`) passa por `requestQuit` -> guarda de nao salvos -> `app.quit()`.
+- Menu de aplicacao existe apenas no macOS, onde o sistema roteia os atalhos de area de transferencia (Cmd+C/V/X/A) pelo menu; sem ele o renderer nunca os recebe. Manter os roles padrao de Edit ao mexer no menu.
 - Ao adicionar formato de exportacao, atualizar `ExportFormat` em `electron/shared.ts`, filtros em `electron/export.ts`, UI em `ExportDialog.tsx`, traducoes nos locales e documentacao.
 - Ao adicionar idioma, atualizar `SUPPORTED_LANGUAGES` em `electron/shared.ts`, criar locale JSON em `src/locales/` e documentar.
 - Paineis inline do workspace (exportacao, configuracoes, sobre) compartilham a estrutura de `.export-dialog`; reutilizar esse padrao ao criar novos.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,11 @@ jobs:
 
   publish:
     name: Publish complete release
-    needs: macos
+    # Waits for macOS so the release is never made public while the DMG is still uploading,
+    # but does not require it: macOS is unsigned and secondary, and a failure there must not
+    # hold back a good Windows and Linux release. The macOS job still fails loudly.
+    needs: [linux, macos]
+    if: always() && needs.linux.result == 'success'
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,32 @@ jobs:
       - name: Build and publish AppImage and DEB
         run: npx electron-builder --linux --x64 --publish always
 
+  macos:
+    name: Build macOS
+    needs: linux
+    runs-on: macos-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # No Apple Developer certificate configured: publish an unsigned build rather than
+      # failing when electron-builder finds no signing identity in the keychain.
+      CSC_IDENTITY_AUTO_DISCOVERY: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Validate tag version
+        run: node -e "const p=require('./package.json'); if(process.env.GITHUB_REF_NAME !== 'v'+p.version) throw new Error('Tag must equal v'+p.version)"
+      - run: npm run typecheck
+      - run: npm run build
+      - name: Build and publish universal DMG and ZIP
+        run: npx electron-builder --mac --publish always
+
   publish:
     name: Publish complete release
-    needs: linux
+    needs: macos
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,22 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- macOS packaging: universal (Apple Silicon + Intel) DMG and ZIP targets, a `dist:mac` script, and a macOS job in the tagged release workflow.
+- Native application menu on macOS, providing the standard Edit roles so clipboard shortcuts reach the renderer.
+
 ### Fixed
 
 - Exported HTML, PDF, and PNG now use the preview's font family, size, and line height. Exports previously declared no font family at all and fell back to the browser's default serif at a different size.
 - PNG export no longer fails on documents taller than roughly 8000 pixels. The capture exceeded Chromium's 16384-pixel texture limit and aborted with `UnknownVizError`; tall documents are now captured in slices and stitched into one image.
+- Quitting on macOS now exits the application instead of only closing the window, while still running the unsaved-changes guard. Dock Quit and Cmd+Q both route through it.
 
 ### Changed
 
 - PNG export now compresses each captured slice as it arrives instead of assembling the whole bitmap in memory first. Peak memory follows the slice height rather than the height of the document: exporting the bundled guide dropped from roughly 500 MB to 165 MB, and a 30000 pixel document no longer approaches a gigabyte. Exports are around 15% slower and the files around 30% larger.
+- Documented the real Node.js requirement (`^20.19.0 || >=22.12.0`) and declared it in `package.json`; the previous "Node.js 18+" claim did not match Vite 7 and electron-vite 5.
+>>>>>>> ea38901 (docs: document macOS distribution and correct Node requirement)
 
 ## [0.1.3] - 2026-07-12
 

--- a/README.md
+++ b/README.md
@@ -117,8 +117,10 @@ To sign locally, install an Apple Developer ID certificate in the keychain and d
 
 1. Update `version` in `package.json` and `package-lock.json`.
 2. Commit changes, then create and push matching tag such as `v0.2.0`.
-3. `.github/workflows/release.yml` validates tag, builds Windows first, then Linux, and publishes draft artifacts.
-4. Workflow makes GitHub Release public only after NSIS/AppImage binaries and `latest.yml`/`latest-linux.yml` are uploaded.
+3. `.github/workflows/release.yml` validates tag, then builds Windows, Linux, and macOS in that order, uploading each platform's artifacts to a draft release. No binary is attached by hand.
+4. Workflow makes GitHub Release public only after every platform succeeds: NSIS, AppImage, DEB, the macOS DMG and ZIP, and the `latest.yml` / `latest-linux.yml` update metadata.
+
+A failure on any platform leaves the release as a draft, so a broken macOS build holds back the Windows and Linux binaries rather than shipping an incomplete release. That is deliberate.
 
 `electron-updater` runs only in packaged Windows NSIS builds and Linux AppImages. Development and deb builds do not self-update. AppImage must live in a user-writable directory to be replaced successfully. Windows production releases should use an Authenticode certificate through electron-builder signing environment variables; never store certificate credentials in repository.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
 
 ## Requirements
 
-- Node.js 18+ (developed on Node 22)
+- Node.js `^20.19.0 || >=22.12.0` (required by Vite 7 and electron-vite 5; packaging also needs `require()` of ES modules, unflagged since Node 22.12)
 - npm
 
 ## Development
@@ -91,6 +91,7 @@ Useful scripts:
 npm run dist
 npm run dist:win
 npm run dist:linux
+npm run dist:mac
 ```
 
 Artifacts are written to `release/`.
@@ -99,8 +100,18 @@ Current packaging targets:
 
 - Windows: NSIS installer, x64, with automatic updates.
 - Linux: AppImage with automatic updates, plus deb for manual installation.
+- macOS: universal (Apple Silicon + Intel) DMG and ZIP, without automatic updates.
 
 File associations for `.md` and `.markdown` are declared in `electron-builder.yml`.
+
+### macOS builds
+
+macOS releases are **not code-signed or notarized**, because that requires a paid Apple Developer account. Consequences:
+
+- Gatekeeper quarantines the app when the DMG is downloaded from the web. Users must either right-click the app and choose *Open*, or clear the quarantine flag: `xattr -dr com.apple.quarantine /Applications/Moji.app`.
+- Automatic updates stay disabled on macOS. Squirrel.Mac refuses to replace an unsigned bundle, so `updater.ts` reports `unsupported` there and users update by downloading a new DMG.
+
+To sign locally, install an Apple Developer ID certificate in the keychain and drop the `CSC_IDENTITY_AUTO_DISCOVERY=false` override; `build/entitlements.mac.plist` and `hardenedRuntime` are already configured for notarization.
 
 ### Publishing a release
 
@@ -115,7 +126,7 @@ File associations for `.md` and `.markdown` are declared in `electron-builder.ym
 
 ```text
 electron/
-  main.ts        Window lifecycle, persisted bounds, file opening, single-instance flow, close guard, IPC registration
+  main.ts        Window lifecycle, persisted bounds, file opening, single-instance flow, close guard, macOS application menu, IPC registration
   preload.ts     Safe renderer API exposed through contextBridge
   shared.ts      Shared IPC names, settings, export types, languages, recent-file limits, supported extensions
   updater.ts     GitHub release checks, update download state, and NSIS/AppImage installation

--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ To sign locally, install an Apple Developer ID certificate in the keychain and d
 1. Update `version` in `package.json` and `package-lock.json`.
 2. Commit changes, then create and push matching tag such as `v0.2.0`.
 3. `.github/workflows/release.yml` validates tag, then builds Windows, Linux, and macOS in that order, uploading each platform's artifacts to a draft release. No binary is attached by hand.
-4. Workflow makes GitHub Release public only after every platform succeeds: NSIS, AppImage, DEB, the macOS DMG and ZIP, and the `latest.yml` / `latest-linux.yml` update metadata.
+4. Workflow makes GitHub Release public once Windows and Linux have succeeded: NSIS, AppImage, DEB, and the `latest.yml` / `latest-linux.yml` update metadata.
 
-A failure on any platform leaves the release as a draft, so a broken macOS build holds back the Windows and Linux binaries rather than shipping an incomplete release. That is deliberate.
+A Windows or Linux failure leaves the release as a draft. A macOS failure does not: the publish step waits for the macOS job to finish, so the release is never made public while the DMG is still uploading, but it does not require it to have succeeded. macOS is unsigned and secondary, and a broken DMG should not hold back a good Windows and Linux release. The macOS job still fails visibly in the workflow.
 
 `electron-updater` runs only in packaged Windows NSIS builds and Linux AppImages. Development and deb builds do not self-update. AppImage must live in a user-writable directory to be replaced successfully. Windows production releases should use an Authenticode certificate through electron-builder signing environment variables; never store certificate credentials in repository.
 

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.files.user-selected.read-write</key>
+  <true/>
+</dict>
+</plist>

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -28,6 +28,25 @@ fileAssociations:
     description: Markdown Document
     role: Editor
     mimeType: text/markdown
+mac:
+  category: public.app-category.productivity
+  darkModeSupport: true
+  artifactName: ${productName}-${version}-${arch}.${ext}
+  # Signing is driven by electron-builder's CSC_* environment variables. Unsigned
+  # local builds still run; Gatekeeper only blocks copies downloaded from the web.
+  hardenedRuntime: true
+  gatekeeperAssess: false
+  entitlements: build/entitlements.mac.plist
+  entitlementsInherit: build/entitlements.mac.plist
+  target:
+    - target: dmg
+      arch:
+        - universal
+    - target: zip
+      arch:
+        - universal
+dmg:
+  artifactName: ${productName}-${version}-${arch}.${ext}
 win:
   artifactName: ${productName}.Setup.${version}.${ext}
   target:

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -22,6 +22,7 @@ import { createUpdateController, type UpdateController } from './updater'
 let mainWindow: BrowserWindow | null = null
 let pendingOpenPath: string | null = null
 let forceQuit = false
+let pendingQuit = false
 let pendingUpdateInstall = false
 let updateController: UpdateController | null = null
 let persistWindowBoundsTimer: NodeJS.Timeout | null = null
@@ -178,6 +179,51 @@ async function openDocument(filePath: string): Promise<void> {
 
 function requestClose(): void {
   mainWindow?.webContents.send(IPC.requestClose)
+}
+
+/** Quit the whole app, not just the window. On macOS closing the last window keeps the app alive. */
+function requestQuit(): void {
+  if (!mainWindow) {
+    forceQuit = true
+    app.quit()
+    return
+  }
+  pendingQuit = true
+  requestClose()
+}
+
+/**
+ * macOS routes clipboard and window shortcuts through the application menu: with no
+ * menu installed, Cmd+C/V/X/A never reach the renderer. Windows and Linux keep no menu
+ * at all, since every action lives in the in-app top bar.
+ */
+function installApplicationMenu(): void {
+  if (process.platform !== 'darwin') {
+    Menu.setApplicationMenu(null)
+    return
+  }
+
+  Menu.setApplicationMenu(
+    Menu.buildFromTemplate([
+      {
+        label: app.name,
+        submenu: [
+          { role: 'about' },
+          { type: 'separator' },
+          { role: 'services' },
+          { type: 'separator' },
+          { role: 'hide' },
+          { role: 'hideOthers' },
+          { role: 'unhide' },
+          { type: 'separator' },
+          // Custom quit so the unsaved-changes guard runs before the app exits.
+          { label: `Quit ${app.name}`, accelerator: 'Command+Q', click: () => requestQuit() }
+        ]
+      },
+      { role: 'editMenu' },
+      { role: 'windowMenu' }
+    ])
+  )
 }
 
 function unavailableUpdateState(): UpdateState {
@@ -387,11 +433,15 @@ function registerIpc(): void {
       if (pendingUpdateInstall) {
         pendingUpdateInstall = false
         if (!updateController?.quitAndInstall()) mainWindow.close()
+      } else if (pendingQuit) {
+        pendingQuit = false
+        app.quit()
       } else {
         mainWindow.close()
       }
     } else if (shouldClose === false) {
       pendingUpdateInstall = false
+      pendingQuit = false
     }
   })
 }
@@ -417,10 +467,17 @@ if (!gotLock) {
     void openDocument(filePath)
   })
 
+  // Dock "Quit" and Cmd+Q must pass through the unsaved-changes guard like any other exit.
+  app.on('before-quit', (e) => {
+    if (forceQuit || !mainWindow) return
+    e.preventDefault()
+    requestQuit()
+  })
+
   app.whenReady().then(() => {
     pendingOpenPath = fileFromArgv(process.argv)
     registerIpc()
-    Menu.setApplicationMenu(null)
+    installApplicationMenu()
     createWindow()
     initializeUpdater()
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -266,6 +266,13 @@ function schedulePersistWindowBounds(win: BrowserWindow): void {
 }
 
 function createWindow(): void {
+  // `forceQuit` is what lets an approved close through the guard. On Windows and Linux the
+  // process ends with the window, so it never outlives its purpose. On macOS the app stays
+  // alive, so a window opened afterwards would inherit the raised flag and close without
+  // ever asking about unsaved changes. Every new window starts with the guard armed.
+  forceQuit = false
+  pendingQuit = false
+
   const iconPath = app.isPackaged ? join(process.resourcesPath, 'icon.png') : join(app.getAppPath(), 'build', 'icon.png')
   mainWindow = new BrowserWindow({
     ...windowOptionsFromSettings(),

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -31,6 +31,19 @@ if (process.platform === 'linux') {
   app.setDesktopName('moji.desktop')
 }
 
+/**
+ * macOS spells `app.name` throughout the application menu: "About …", "Hide …", "Quit …".
+ * That name comes from the lowercase npm package name, so the menu would read "Quit moji".
+ *
+ * `app.name` also decides where `userData` lives, so renaming the app would move the
+ * settings directory and orphan the preferences of everyone already running Moji, on every
+ * platform. The name is corrected for display and the settings directory is pinned to the
+ * one shipped builds already use.
+ */
+const SETTINGS_DIRECTORY = 'moji'
+app.setName('Moji')
+app.setPath('userData', join(app.getPath('appData'), SETTINGS_DIRECTORY))
+
 const IMAGE_EXTENSIONS = new Set(['.avif', '.bmp', '.gif', '.ico', '.jpeg', '.jpg', '.png', '.svg', '.webp'])
 const SAMPLE_FILES = new Set([
   'markdown-guide.en.md',

--- a/openspec/changes/add-macos-support/.openspec.yaml
+++ b/openspec/changes/add-macos-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/add-macos-support/design.md
+++ b/openspec/changes/add-macos-support/design.md
@@ -41,6 +41,12 @@ This leaves the pre-existing `Native application menu` requirement in `app-shell
 
 `forceQuit` remains the single escape hatch that lets the second, real quit through without re-prompting.
 
+### Re-arm the guard on every new window
+
+`forceQuit` is raised once a close is approved and was never lowered. On Windows and Linux the process dies with the window, so the flag never outlives its purpose. On macOS the app survives its last window, so a window opened afterwards inherited the raised flag and closed **without ever asking about unsaved changes**: work was discarded in silence.
+
+The flag is therefore cleared in `createWindow`, so every window starts with the guard armed. This is a pre-existing defect that only becomes reachable once the app correctly stays alive on macOS, which is why it is fixed here rather than left for later.
+
 ### Leave automatic updates unsupported on macOS
 
 Squirrel.Mac refuses to replace an unsigned bundle, so enabling the updater would surface a permanently failing flow. `supportsAutomaticUpdates()` already returns false on darwin; the behavior is now documented rather than incidental. macOS users update by downloading a new DMG.

--- a/openspec/changes/add-macos-support/design.md
+++ b/openspec/changes/add-macos-support/design.md
@@ -1,0 +1,61 @@
+## Context
+
+`electron/main.ts` already contains darwin branches (`open-file`, `window-all-closed`, `activate`), so macOS was partially anticipated but never packaged or exercised. Two platform assumptions inherited from Windows and Linux break on macOS:
+
+- `Menu.setApplicationMenu(null)` is harmless where the menu is only a visible bar, but on macOS the application menu is what dispatches clipboard shortcuts. With no menu, Cmd+C, Cmd+V, Cmd+X and Cmd+A never reach the renderer, disabling copy and paste in the CodeMirror editor and in the search fields.
+- The close guard ends in `mainWindow.close()`. On Windows and Linux the last window closing quits the process. On macOS `window-all-closed` deliberately does not quit, so every exit path would close the window and leave Moji running in the Dock.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Produce an installable macOS artifact for both CPU architectures.
+- Restore clipboard shortcuts on macOS.
+- Make quit mean quit, without bypassing the unsaved-changes guard.
+
+**Non-Goals:**
+
+- Code signing and notarization, which require a paid Apple Developer account.
+- Automatic updates on macOS, which depend on signing.
+- Moving app actions (Open, Save, Export, theme) into the native menu; they stay in the in-app top bar on every platform.
+
+## Decisions
+
+### Ship a universal binary rather than per-architecture artifacts
+
+One DMG runs on Apple Silicon and Intel, so the download page needs no CPU choice and a user cannot pick the wrong build. The cost is size: the universal DMG is roughly 215 MB against roughly 110 MB per single-architecture build, because both Electron binaries travel together. Distribution simplicity outweighs bytes for a desktop editor released a few times a year. Revisit if release size becomes a constraint.
+
+### Install the menu only on macOS
+
+Windows and Linux keep `Menu.setApplicationMenu(null)`: their menu bar is redundant with the in-app top bar and hiding it is deliberate. macOS gets the system roles it actually needs, `editMenu` and `windowMenu`, plus an app menu. This keeps one platform-specific branch instead of a cross-platform menu that would duplicate the top bar.
+
+### Keep the app menu limited to system roles
+
+The menu carries no Open, Save, Export or theme items. Those already exist in the top bar with working shortcuts, and duplicating them in a menu would create two sources of truth for enablement state (read-only guides, no active document). The menu exists to satisfy a macOS system contract, not to become a second UI.
+
+This leaves the pre-existing `Native application menu` requirement in `app-shell` unmet, as it has been since it was written. The requirement is rewritten to describe the shipped behavior instead of continuing to assert a menu that does not exist on any platform.
+
+### Route quit through the renderer guard with an explicit flag
+
+`requestQuit()` sets `pendingQuit` and asks the renderer to confirm, exactly like a window close. `confirmClose(true)` then branches on the flag: `app.quit()` when quitting, `mainWindow.close()` when merely closing a window. An `app.on('before-quit')` handler catches the paths that do not originate from the menu, notably Quit from the Dock context menu, and redirects them into the same guard.
+
+`forceQuit` remains the single escape hatch that lets the second, real quit through without re-prompting.
+
+### Leave automatic updates unsupported on macOS
+
+Squirrel.Mac refuses to replace an unsigned bundle, so enabling the updater would surface a permanently failing flow. `supportsAutomaticUpdates()` already returns false on darwin; the behavior is now documented rather than incidental. macOS users update by downloading a new DMG.
+
+## Risks / Trade-offs
+
+- [Unsigned build is quarantined by Gatekeeper] → Documented in the README, with both the right-click Open path and the `xattr -dr com.apple.quarantine` command. `hardenedRuntime` and an entitlements file are configured so enabling signing later is a credentials change, not a code change.
+- [Cmd+Q accelerator in the menu could bypass the guard] → The quit item is a custom item calling `requestQuit()`, not `role: 'quit'`, which would call `app.quit()` directly.
+- [`before-quit` could recurse when the guard approves the exit] → The handler returns early once `forceQuit` is set, which happens before `app.quit()` is called.
+- [Universal DMG doubles download size] → Accepted; see the decision above.
+
+## Migration Plan
+
+No persisted state and no IPC contract changes. Windows and Linux packaging is untouched: the menu branch and the quit branch are both no-ops off darwin.
+
+## Open Questions
+
+None.

--- a/openspec/changes/add-macos-support/proposal.md
+++ b/openspec/changes/add-macos-support/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Moji ships for Windows and Linux only. macOS users have no artifact to install, even though the codebase already handles darwin in its file-association and window-lifecycle paths. Packaging alone is not enough: two macOS platform behaviors are currently broken, and shipping without fixing them would produce an app that cannot copy text and cannot quit.
+
+## What Changes
+
+- Package macOS as a universal DMG and ZIP covering Apple Silicon and Intel.
+- Install a native application menu on macOS so the system routes clipboard shortcuts to the renderer.
+- Route every macOS exit path through the existing unsaved-changes guard and then actually quit the app.
+- Build and publish macOS artifacts from the tagged release workflow.
+- Keep automatic updates unsupported on macOS, since unsigned bundles cannot self-replace.
+- Correct the documented Node.js requirement, which no longer matches the toolchain.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `app-shell`: macOS becomes a supported platform, gains a native application menu, and separates closing the window from quitting the app.
+- `automatic-updates`: macOS is declared an unsupported package format.
+
+## Impact
+
+- Adds a `mac` target and entitlements to `electron-builder.yml`, plus a `dist:mac` script.
+- Adds menu construction and a quit path to `electron/main.ts`.
+- Adds a macOS job to `.github/workflows/release.yml`.
+- Declares `engines` in `package.json` and corrects the README requirement.
+- Does not change the renderer, IPC contracts, or app version.

--- a/openspec/changes/add-macos-support/specs/app-shell/spec.md
+++ b/openspec/changes/add-macos-support/specs/app-shell/spec.md
@@ -42,3 +42,7 @@ The system SHALL treat quitting the application as distinct from closing its win
 #### Scenario: Quit with no unsaved documents
 - **WHEN** the user quits and no document has unsaved changes
 - **THEN** the application process terminates rather than leaving a windowless app running
+
+#### Scenario: The guard survives a window being closed and reopened
+- **WHEN** the user closes the window on macOS, leaving the app running, then reopens it from the Dock and makes an unsaved edit
+- **THEN** closing that window raises the unsaved-changes confirmation again, rather than discarding the work silently

--- a/openspec/changes/add-macos-support/specs/app-shell/spec.md
+++ b/openspec/changes/add-macos-support/specs/app-shell/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: Cross-platform desktop application
+The system SHALL run as a desktop application on Windows, Linux, and macOS, built with Electron and a React renderer, packaged into installable artifacts for each platform.
+
+#### Scenario: Launch on Windows
+- **WHEN** a user runs the installed application on Windows
+- **THEN** the application window opens showing the empty/welcome state without errors
+
+#### Scenario: Launch on Linux
+- **WHEN** a user runs the packaged application (AppImage or deb) on Linux
+- **THEN** the application window opens showing the empty/welcome state without errors
+
+#### Scenario: Launch on macOS
+- **WHEN** a user runs the packaged application (universal DMG or ZIP) on Apple Silicon or Intel macOS
+- **THEN** the application window opens showing the empty/welcome state without errors
+
+### Requirement: Native application menu
+The system SHALL install a native application menu on macOS exposing the standard system roles, because macOS dispatches clipboard and window shortcuts through the application menu. The system SHALL NOT install a menu on Windows or Linux, where every action is reachable from the in-app top bar.
+
+#### Scenario: Clipboard shortcuts in the editor on macOS
+- **WHEN** the user presses Cmd+C, Cmd+V, Cmd+X, or Cmd+A while editing a document or typing in a search field on macOS
+- **THEN** the corresponding clipboard action is applied to the focused field
+
+#### Scenario: No menu bar on Windows and Linux
+- **WHEN** the application window is focused on Windows or Linux
+- **THEN** no application menu bar is shown, and file, search, export, and theme actions remain available from the in-app top bar
+
+## ADDED Requirements
+
+### Requirement: Quitting is distinct from closing the window
+The system SHALL treat quitting the application as distinct from closing its window on macOS, where closing the last window leaves the process running. Every exit path SHALL pass through the unsaved-changes guard before the application terminates.
+
+#### Scenario: Quit with unsaved documents on macOS
+- **WHEN** the user chooses Quit from the application menu or the Dock, or presses Cmd+Q, while a document has unsaved changes
+- **THEN** the unsaved-changes confirmation appears, and the application terminates only after the user saves or discards
+
+#### Scenario: Cancel a quit
+- **WHEN** the user cancels the unsaved-changes confirmation raised by a quit
+- **THEN** the application stays open with every document and its unsaved content intact
+
+#### Scenario: Quit with no unsaved documents
+- **WHEN** the user quits and no document has unsaved changes
+- **THEN** the application process terminates rather than leaving a windowless app running

--- a/openspec/changes/add-macos-support/specs/automatic-updates/spec.md
+++ b/openspec/changes/add-macos-support/specs/automatic-updates/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Packaged app checks stable GitHub releases
+The system SHALL check for a newer stable GitHub Release after startup when running as an installed Windows NSIS application or Linux AppImage, and SHALL not perform update checks in development or unsupported package formats. Linux DEB and macOS packages SHALL be treated as unsupported package formats.
+
+#### Scenario: New stable release exists
+- **WHEN** a supported packaged application starts and GitHub contains a higher stable semantic version
+- **THEN** the application reports that version as available without interrupting document editing
+
+#### Scenario: No new release exists
+- **WHEN** a supported packaged application checks and current version is latest
+- **THEN** the update state becomes up to date without showing an intrusive notice
+
+#### Scenario: User checks manually from About view
+- **WHEN** user selects the icon-labelled check-for-updates action at the end of the About view
+- **THEN** application checks GitHub Releases and shows current check result in the About view and global update notice when action is needed
+
+#### Scenario: Linux DEB build starts
+- **WHEN** Moji runs on Linux without the `APPIMAGE` runtime marker
+- **THEN** automatic update is marked unsupported and no replacement is attempted
+
+#### Scenario: macOS build starts
+- **WHEN** Moji runs on macOS
+- **THEN** automatic update is marked unsupported and no replacement is attempted, because Squirrel.Mac cannot replace an unsigned application bundle

--- a/openspec/changes/add-macos-support/tasks.md
+++ b/openspec/changes/add-macos-support/tasks.md
@@ -8,6 +8,7 @@
 
 - [x] 2.1 Install a native application menu on macOS with the standard Edit and Window roles
 - [x] 2.2 Route Cmd+Q, the Dock Quit item, and `before-quit` through the unsaved-changes guard and quit the app
+- [x] 2.3 Re-arm the guard on every new window, so a window reopened after the app outlives its last one does not inherit a raised `forceQuit`
 
 ## 3. Toolchain and documentation
 
@@ -16,3 +17,4 @@
 - [x] 3.3 Run TypeScript typecheck and produce a macOS build
 - [x] 3.4 Verify the installed menu from the main process: an app menu, an Edit menu carrying the clipboard roles, and a Window menu
 - [x] 3.5 Verify the quit flow end to end: with an unsaved edit, Quit raises the guard and leaves the app running; discarding terminates the process
+- [x] 3.6 Verify the guard is still armed on a window reopened after the last one was closed

--- a/openspec/changes/add-macos-support/tasks.md
+++ b/openspec/changes/add-macos-support/tasks.md
@@ -1,0 +1,18 @@
+## 1. Packaging
+
+- [x] 1.1 Add macOS universal DMG and ZIP targets and entitlements to `electron-builder.yml`
+- [x] 1.2 Add the `dist:mac` script to `package.json`
+- [x] 1.3 Add a macOS job to the tagged release workflow, before the publish job
+
+## 2. macOS platform behavior
+
+- [x] 2.1 Install a native application menu on macOS with the standard Edit and Window roles
+- [x] 2.2 Route Cmd+Q, the Dock Quit item, and `before-quit` through the unsaved-changes guard and quit the app
+
+## 3. Toolchain and documentation
+
+- [x] 3.1 Declare the real Node.js requirement in `engines` and correct the README
+- [x] 3.2 Document unsigned distribution, Gatekeeper quarantine, and the absence of macOS automatic updates
+- [x] 3.3 Run TypeScript typecheck and produce a macOS build
+- [x] 3.4 Verify the installed menu from the main process: an app menu, an Edit menu carrying the clipboard roles, and a Window menu
+- [x] 3.5 Verify the quit flow end to end: with an unsaved edit, Quit raises the guard and leaves the app running; discarding terminates the process

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
   },
   "license": "MIT",
   "main": "out/main/main.js",
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  },
   "scripts": {
     "dev": "node scripts/run-electron-vite.cjs dev",
     "build": "electron-vite build",
@@ -33,7 +36,8 @@
     "preview": "node scripts/run-electron-vite.cjs preview",
     "dist": "electron-vite build && electron-builder",
     "dist:win": "electron-vite build && electron-builder --win",
-    "dist:linux": "electron-vite build && electron-builder --linux"
+    "dist:linux": "electron-vite build && electron-builder --linux",
+    "dist:mac": "electron-vite build && electron-builder --mac"
   },
   "dependencies": {
     "@codemirror/commands": "^6.7.1",


### PR DESCRIPTION
## Why

Moji ships for Windows and Linux only. macOS has no artifact at all, even though the code already handles darwin in its file-association and window-lifecycle paths.

Packaging alone would not have been enough. Two macOS behaviors are broken today, and shipping without fixing them would produce an app that **cannot copy text and cannot quit**.

## What this does

**Packaging.** A universal DMG and ZIP (Apple Silicon and Intel in one download), a `dist:mac` script, and a macOS job in the tagged release workflow.

**The clipboard.** `main.ts` calls `Menu.setApplicationMenu(null)`. On Windows and Linux that only hides a redundant menu bar. On macOS the application menu is what dispatches clipboard shortcuts, so with no menu **Cmd+C, Cmd+V, Cmd+X and Cmd+A never reach the renderer**: no copy or paste in the CodeMirror editor or in the search fields. A menu is now installed on darwin only, carrying the standard `editMenu` and `windowMenu` roles. Windows and Linux keep no menu, exactly as before.

**Quitting.** The close guard ends in `mainWindow.close()`. On Windows and Linux, closing the last window ends the process. On macOS `window-all-closed` deliberately does not quit, so every exit path would have closed the window and left Moji alive in the Dock. Quit is now distinct from closing a window: Cmd+Q, the Dock's Quit, and `before-quit` all route through `requestQuit`, which runs the unsaved-changes guard and then actually terminates the app.

The Quit menu item is a custom item rather than `role: 'quit'`, precisely so it cannot bypass the guard.

**The release gate.** The macOS job slots into the existing chain (`windows` → `linux` → `macos`). The `publish` job builds nothing: each platform job uploads its artifacts to a **draft** release (`releaseType: draft`), and `publish` only flips that draft public.

macOS is deliberately **not** allowed to block a release:

```yaml
publish:
  needs: [linux, macos]
  if: always() && needs.linux.result == 'success'
```

It *waits* for the macOS job, so the release is never made public while the DMG is still uploading, but it does not *require* it. A broken, unsigned, secondary macOS build should not hold back a good Windows and Linux release. The macOS job still fails loudly in the workflow.

Depending on `linux` alone would not have worked: `macos` also depends on `linux`, so the two would run as siblings and `publish` could make the release public mid-upload, with `electron-builder` then trying to attach the DMG to a release that is no longer a draft.

No binary is attached by hand: the runner builds the universal DMG and ZIP and uploads them itself. The README's release steps are updated to match.

**A latent data-loss bug, surfaced by the above.** `forceQuit` is the flag that lets an approved close through the guard. It was raised on approval and never lowered. On Windows and Linux that is harmless: the process dies with the window. On macOS the app now correctly stays alive after its last window closes, and a window opened afterwards **inherited the raised flag and closed without ever asking about unsaved changes**.

I found this by testing the reopen path rather than assuming it:

```
1) close the window with unsaved changes -> guard shown: YES
   app still running after the window closed (macOS behavior): YES
2) in the REOPENED window, close with unsaved changes:
   window survived: NO | guard shown: NO
=> work discarded in silence
```

The flag is now cleared in `createWindow`, so every window starts with the guard armed. Same test after the fix:

```
2) in the REOPENED window, close with unsaved changes:
   window survived: YES | guard shown: YES
```

This is a pre-existing defect that only becomes reachable once the app behaves correctly on macOS, which is why it is fixed here rather than filed away.

**The app is called Moji, not moji.** macOS spells `app.name` throughout the application menu, and that name comes from the lowercase npm package name, so the packaged app read `moji` and `Quit moji`. On Windows and Linux nobody ever saw it; on macOS it is the name in the menu bar all day.

The obvious fix, adding `productName` to `package.json`, carries a trap: `app.name` also decides where `userData` lives. Renaming the app would move the settings directory **on every platform**, orphaning the recent files, language, and window bounds of everyone already running Moji. So the name is corrected for display and the settings directory is pinned to the one shipped builds already use:

```ts
app.setName('Moji')
app.setPath('userData', join(app.getPath('appData'), 'moji'))
```

Verified in the packaged bundle: the menu reads `Moji | Edit | Window` with `Quit Moji`, and `app.getPath('userData')` still resolves to `.../Application Support/moji`.

**Node.** The README claimed Node 18+. No version of 18 can run this toolchain: Vite 7 and electron-vite 5 both require `^20.19.0 || >=22.12.0`, and packaging needs `require()` of ES modules, which is unflagged only from 22.12. The real requirement is now documented and declared in `engines`.

## Testing

- `npm run typecheck` passes, and the suite passes apart from `settings.test.ts`, which already fails on `main` for unrelated reasons (its module-level cache is not reset between cases).

**The menu, read back from the main process.** The earlier blocker was that UI scripting needs an accessibility permission. Asking Electron directly sidesteps that:

```
menus: Moji | Edit | Window
  App menu: about, services, hide, hideOthers, unhide
    quit item: label="Quit Moji"  role=(custom)  accelerator=Command+Q
  Edit:     undo, redo, cut, copy, paste, pasteAndMatchStyle, delete, selectAll
  Window:   minimize, zoom, front
```

The Edit menu carries the clipboard roles, which is what restores Cmd+C and Cmd+V. The quit item is custom, which is what keeps the guard in the path. Read from the packaged bundle, not a dev run.

**The quit flow, end to end.** Driving the real app with Playwright: open a document, type into the editor to make it dirty, then fire the menu's Quit item.

```
document dirty?                 tab shows "• moji-quit-test.md"
1) Quit with unsaved changes -> guard dialog opened: YES | app still running: YES
2) Discard                   -> process exited: YES
```

Both halves matter. The first proves Quit cannot silently discard work. The second proves the app really exits, rather than closing its window and lingering in the Dock, which is the bug being fixed.

**Packaging.** Built from this branch with `npm run dist:mac`:

- `Moji-0.1.3-universal.dmg`, 227 MB, plus the matching ZIP.
- `lipo` reports `x86_64 arm64` on the app binary, so it really is universal.
- `Info.plist` carries `com.alexishida.moji`, the product name `Moji`, and the `.md` document type.
- `icon.icns` is generated from the existing 1024px PNG; no new asset was needed.

The menu dump above was taken from that packaged bundle, not from a dev run.

## Limitations, stated up front

- **The build is not signed or notarized**, which needs a paid Apple Developer account. Gatekeeper will quarantine a DMG downloaded from the web: users must right-click and choose *Open*, or run `xattr -dr com.apple.quarantine /Applications/Moji.app`. `hardenedRuntime` and an entitlements file are already configured, so enabling signing later is a credentials change rather than a code change.
- **Automatic updates stay off on macOS.** Squirrel.Mac refuses to replace an unsigned bundle, so enabling the updater would only surface a permanently failing flow. `supportsAutomaticUpdates()` already returns false on darwin; the change documents that rather than pretending otherwise.
- **The universal DMG is around 215 MB**, since both Electron binaries travel together. Two per-architecture DMGs would be roughly 110 MB each. I chose one download over a smaller one, so nobody can pick the wrong build; that is easy to reverse if the size matters more.
