### PR TITLE
chore: merge the 0.1.4 release back into main

### DIFF
--- a/.ai-framework/DESIGN.md
+++ b/.ai-framework/DESIGN.md
@@ -154,6 +154,7 @@ O preview deve manter suporte visual para:
 - blockquotes
 - codigo inline e blocos com highlight.js
 - botao de copiar em blocos de codigo, oculto durante selecao do bloco
+- diagramas Mermaid renderizados no tema atual, clicaveis para abrir o visualizador `.diagram-modal`
 - imagens responsivas
 - destaque de busca via `.search-highlight` quando a busca estiver conectada
 

--- a/.ai-framework/RULES.md
+++ b/.ai-framework/RULES.md
@@ -11,7 +11,7 @@ Projeto atual: Moji, aplicativo desktop Electron + React + TypeScript para abrir
 - Manter alteracoes pequenas e alinhadas ao pedido.
 - Preservar mudancas locais de usuario; nao reverter arquivos fora do escopo solicitado.
 - Preferir `rg` para localizar arquivos/texto.
-- Usar `npm run typecheck` para validar TypeScript quando houver alteracao em codigo.
+- Usar `npm run typecheck` para validar TypeScript e `npm test` (Vitest) para rodar a suite quando houver alteracao em codigo.
 
 ## Stack e Arquitetura
 
@@ -21,14 +21,15 @@ Projeto atual: Moji, aplicativo desktop Electron + React + TypeScript para abrir
 - `preload.ts`: expoe API segura ao renderer via `contextBridge` com tipagem completa (`RendererApi`).
 - `shared.ts`: tipos e constantes compartilhados entre main, preload e renderer (tipos de resultado IPC, `Settings`, `ExportFormat`, `SUPPORTED_LANGUAGES`, `IPC` channels).
 - `settings.ts`: persiste configuracoes do usuario em `settings.json` no `userData`; resolve idioma inicial a partir do locale do SO; aplica limites numericos (`boundedNumber`).
-- `export.ts`: exporta documento ativo como PDF (via `printToPDF` em `BrowserWindow` oculta), PNG (via `capturePage().toPNG()`) ou HTML (escrita direta). Suporta A4/Letter/Legal e portrait/landscape.
+- `export.ts`: exporta documento ativo como PDF (via `printToPDF` em `BrowserWindow` oculta), PNG ou HTML (escrita direta). Suporta A4/Letter/Legal e portrait/landscape; documentos altos sao capturados em fatias para respeitar o limite de textura do Chromium.
+- `png.ts`: encoder PNG em streaming que comprime cada fatia capturada ao chegar, mantendo o pico de memoria proporcional a fatia e nao a altura total do documento.
 - `updater.ts`: gerencia verificacao, download e instalacao de GitHub Releases com `electron-updater`; habilitado apenas em Windows NSIS empacotado e Linux AppImage.
 
 ### Renderer (`src/`)
 
 - `App.tsx`: estado principal (documentos, aba ativa, modo view/edit/search/export, tema Markdown, drag-drop, outline scroll-spy, contagem de palavras/linhas/tokens).
-- `src/components/`: 14 componentes React (`AboutDialog`, `ConfirmDialog`, `DocumentTabs`, `Editor`, `ExportDialog`, `icons`, `OutlineTree`, `Preview`, `SettingsButton`, `SettingsDialog`, `Sidebar`, `StatusBar`, `TopBar`, `Welcome`).
-- `src/lib/`: utilitarios (`exportHtml`, `markdown`, `outline`, `previewScroll`, `useDebounced`).
+- `src/components/`: 15 componentes React (`AboutDialog`, `ConfirmDialog`, `DocumentTabs`, `Editor`, `ExportDialog`, `icons`, `MermaidDiagramDialog`, `OutlineTree`, `Preview`, `SettingsButton`, `SettingsDialog`, `Sidebar`, `StatusBar`, `TopBar`, `Welcome`).
+- `src/lib/`: utilitarios (`exportHtml`, `markdown`, `mermaid`, `mermaidGuide`, `outline`, `previewScroll`, `useDebounced`).
 - `src/locales/`: arquivos JSON de traducao para `en`, `pt-BR`, `es`, `ja`, `zh`, `ru`.
 - `src/styles/`: `theme.css` (tokens), `markdown.css` (preview/exportacao), `app.css` (layout).
 - `src/types/`: `api.d.ts` (tipagem da API do preload), `vite-env.d.ts`.
@@ -43,9 +44,11 @@ Projeto atual: Moji, aplicativo desktop Electron + React + TypeScript para abrir
 ### Stack tecnica
 
 - Markdown renderizado por `markdown-it` com plugins (`markdown-it-anchor`, `markdown-it-task-lists`, `markdown-it-footnote`, `markdown-it-deflist`, `markdown-it-sub`, `markdown-it-sup`, `markdown-it-mark`, `markdown-it-ins`, `markdown-it-abbr`, `markdown-it-emoji`, `markdown-it-texmath`), formulas LaTeX via `katex`, codigo destacado com `highlight.js` e HTML sanitizado com `DOMPurify`.
+- Diagramas renderizados por `mermaid`, com cache de resultado e exportacao individual em PNG.
 - Editor baseado em CodeMirror 6 (`@codemirror/commands`, `@codemirror/lang-markdown`, `@codemirror/search`).
 - Internacionalizacao com `i18next` + `react-i18next`.
 - Build/desenvolvimento com `electron-vite`.
+- Testes com `vitest` (`npm test`).
 - Empacotamento com `electron-builder` (NSIS para Windows, AppImage/deb para Linux).
 - Atualizacao automatica com `electron-updater` e metadados publicados em GitHub Releases.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,27 @@ All notable changes to this project will be documented in this file.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [0.1.4] - 2026-07-13
+
+### Added
+
+- Mermaid diagram rendering: every valid fenced `mermaid` block renders in the preview (flowcharts, sequence, Gantt, class, ER, state, journey, and more), following the current light/dark reading theme. Render results are cached so repeated previews reuse the last diagram, and malformed blocks stay readable as code.
+- Mermaid diagram viewer: clicking a diagram opens a modal with fixed zoom levels (10%–1000%), fit-to-view, free-drag panning, a minimap above 100%, `< current/total >` navigation across all diagrams in the document, and per-diagram PNG export named `file-diagram-name-n.png`.
+- Mermaid diagrams embedded as self-contained SVG in HTML, PDF, and PNG exports.
+- Mermaid section added to the bundled Markdown guide for every supported language.
+- Vitest test suite covering Markdown rendering, Mermaid parsing, export, PNG streaming, settings, outline, and preview scroll-spy (`npm test`).
 
 ### Fixed
 
 - Exported HTML, PDF, and PNG now use the preview's font family, size, and line height. Exports previously declared no font family at all and fell back to the browser's default serif at a different size.
 - PNG export no longer fails on documents taller than roughly 8000 pixels. The capture exceeded Chromium's 16384-pixel texture limit and aborted with `UnknownVizError`; tall documents are now captured in slices and stitched into one image.
+- Drag-and-drop overlay no longer stays stuck when the pointer leaves the window over a nested element during a drag.
+- Mermaid diagram viewer title now shows the diagram type name in the active language instead of a fixed English string; an author-provided diagram `title` is still kept verbatim.
 
 ### Changed
 
 - PNG export now compresses each captured slice as it arrives instead of assembling the whole bitmap in memory first. Peak memory follows the slice height rather than the height of the document: exporting the bundled guide dropped from roughly 500 MB to 165 MB, and a 30000 pixel document no longer approaches a gigabyte. Exports are around 15% slower and the files around 30% larger.
+- Windows installer artifact now uses a dotted version in its filename (`Moji.Setup.0.1.4.exe`).
 
 ## [0.1.3] - 2026-07-12
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">Built with Electron, React, TypeScript, and electron-vite.</p>
 
-<p align="center"><strong>Current version:</strong> v0.1.3</p>
+<p align="center"><strong>Current version:</strong> v0.1.4</p>
 
 <p align="center">
   <img src="docs/repository-open-graph.png" alt="reposytory-open-graph" width="100%" />
@@ -16,11 +16,11 @@
 
 <p align="center">
   <strong>Download:</strong>
-  <a href="https://github.com/alexishida/Moji/releases/download/v0.1.3/Moji.Setup.0.1.3.exe">Windows</a>
+  <a href="https://github.com/alexishida/Moji/releases/download/v0.1.4/Moji.Setup.0.1.4.exe">Windows</a>
   ·
-  <a href="https://github.com/alexishida/Moji/releases/download/v0.1.3/Moji-0.1.3-x86_64.AppImage">Linux (AppImage)</a>
+  <a href="https://github.com/alexishida/Moji/releases/download/v0.1.4/Moji-0.1.4-x86_64.AppImage">Linux (AppImage)</a>
   ·
-  <a href="https://github.com/alexishida/Moji/releases/download/v0.1.3/Moji-0.1.3-amd64.deb">Linux (DEB)</a>
+  <a href="https://github.com/alexishida/Moji/releases/download/v0.1.4/Moji-0.1.4-amd64.deb">Linux (DEB)</a>
 </p>
 
 
@@ -75,6 +75,7 @@
 npm install
 npm run dev
 npm run typecheck
+npm test
 npm run build
 ```
 
@@ -82,6 +83,7 @@ Useful scripts:
 
 - `npm run dev`: launch Electron with hot reload.
 - `npm run typecheck`: run TypeScript checks without emitting files.
+- `npm test`: run the Vitest suite once (`npm run test:watch` for watch mode).
 - `npm run build`: build main, preload, and renderer into `out/`.
 - `npm run preview`: run the built app preview.
 
@@ -121,11 +123,12 @@ electron/
   updater.ts     GitHub release checks, update download state, and NSIS/AppImage installation
   settings.ts    User settings persistence, window bounds, recent files, preview theme, and last dialog directory
   export.ts      HTML/PDF/PNG export implementation with remembered output directory
+  png.ts         Streaming PNG encoder used to keep tall-document exports within memory
 
 src/
   App.tsx        Renderer state, document actions, close guard wiring, mode switching
-  components/    Top bar, tabs, sidebar, outline tree, preview, editor, export/settings/about dialogs, confirm dialog, welcome view
-  lib/           Markdown rendering, outline extraction, preview scroll-spy, export HTML, hooks
+  components/    Top bar, tabs, sidebar, outline tree, preview, Mermaid viewer, editor, export/settings/about dialogs, confirm dialog, welcome view
+  lib/           Markdown rendering, Mermaid rendering, outline extraction, preview scroll-spy, export HTML, hooks
   locales/       en, pt-BR, es, ja, zh, ru translation files
   styles/        Theme tokens, app shell CSS, Markdown preview CSS
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moji",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moji",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@codemirror/commands": "^6.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moji",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "desktopName": "moji.desktop",
   "description": "Clean cross-platform Markdown viewer and editor (React + Electron)",
   "homepage": "https://github.com/alexishida/Moji",

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -32,7 +32,11 @@ export function Preview({ html, documentName, mdTheme, searchTerm, settings, cla
     const diagrams = Array.from(bodyRef.current?.querySelectorAll<SVGSVGElement>('.mermaid-diagram svg') ?? [])
     const svg = diagrams[index]
     if (!svg) return
-    const name = svg.closest<HTMLElement>('.mermaid-diagram')?.dataset.mermaidName ?? t('preview.diagramTitle')
+    const container = svg.closest<HTMLElement>('.mermaid-diagram')
+    const type = container?.dataset.mermaidType
+    // Author-provided titles stay verbatim; type names are localized.
+    const name = container?.dataset.mermaidTitle
+      ?? (type ? t(`preview.diagramTypes.${type}`, { defaultValue: t('preview.diagramTitle') }) : t('preview.diagramTitle'))
     setActiveDiagram({ svgMarkup: svg.outerHTML, name, index: index + 1, total: diagrams.length })
   }, [t])
 

--- a/src/index.html
+++ b/src/index.html
@@ -13,7 +13,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400&display=swap"
       rel="stylesheet"
     />
-    <title>Moji v0.1.3</title>
+    <title>Moji v0.1.4</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/lib/mermaid.test.ts
+++ b/src/lib/mermaid.test.ts
@@ -33,7 +33,7 @@ describe('renderMermaidFlowcharts', () => {
     }))
     expect(state.render).toHaveBeenCalledWith(expect.stringMatching(/^moji-mermaid-/), 'flowchart TD\n  Start --> End')
     expect(html).toContain('data-mermaid-rendered="true"')
-    expect(html).toContain('data-mermaid-name="Flowchart"')
+    expect(html).toContain('data-mermaid-type="flowchart"')
     expect(html).toContain('<svg class="mermaid">')
     expect(html).toContain('<style>.node{fill:red}</style>')
     expect(html).not.toContain('onclick')
@@ -49,13 +49,24 @@ describe('renderMermaidFlowcharts', () => {
     expect(html).toContain('<svg class="mermaid"')
   })
 
-  it('uses a Mermaid title as the diagram name', async () => {
+  it('keeps a Mermaid title verbatim as the diagram name', async () => {
     const html = await renderMermaidFlowcharts(
       '<pre class="hljs mermaid-diagram-candidate"><code>pie title Vendas\n  "Produto" : 10</code></pre>',
       'light'
     )
 
-    expect(html).toContain('data-mermaid-name="Vendas"')
+    expect(html).toContain('data-mermaid-title="Vendas"')
+    expect(html).toContain('data-mermaid-type="pie"')
+  })
+
+  it('emits a canonical type key for translation', async () => {
+    const html = await renderMermaidFlowcharts(
+      '<pre class="hljs mermaid-diagram-candidate"><code>classDiagram\n  Account --&gt; Ledger</code></pre>',
+      'light'
+    )
+
+    expect(html).toContain('data-mermaid-type="classDiagram"')
+    expect(html).not.toContain('data-mermaid-title')
   })
 
   it.each([

--- a/src/lib/mermaid.ts
+++ b/src/lib/mermaid.ts
@@ -70,36 +70,42 @@ function cacheSvg(key: string, svg: string | null): void {
   svgCache.set(key, svg)
 }
 
-function diagramName(source: string): string {
-  const title = source.match(/^\s*title\s*:?\s*(.+?)\s*$/im)?.[1]
-    ?? source.match(/^\s*pie(?:\s+showData)?\s+title\s+(.+?)\s*$/im)?.[1]
-  if (title) return title
+/** Canonical type keys, translated at display time under `preview.diagramTypes`. */
+const DIAGRAM_TYPE_KEYS: Record<string, string> = {
+  flowchart: 'flowchart',
+  graph: 'flowchart',
+  sequencediagram: 'sequenceDiagram',
+  classdiagram: 'classDiagram',
+  statediagram: 'stateDiagram',
+  'statediagram-v2': 'stateDiagram',
+  erdiagram: 'erDiagram',
+  journey: 'journey',
+  gantt: 'gantt',
+  pie: 'pie',
+  gitgraph: 'gitGraph',
+  mindmap: 'mindmap',
+  timeline: 'timeline',
+  quadrantchart: 'quadrantChart',
+  requirementdiagram: 'requirementDiagram',
+  'xychart-beta': 'xyChart',
+  'sankey-beta': 'sankey',
+  'block-beta': 'block',
+  'architecture-beta': 'architecture',
+  'packet-beta': 'packet',
+  kanban: 'kanban'
+}
 
+/** Explicit author-provided title, kept verbatim and never translated. */
+function diagramTitle(source: string): string | null {
+  return source.match(/^\s*title\s*:?\s*(.+?)\s*$/im)?.[1]
+    ?? source.match(/^\s*pie(?:\s+showData)?\s+title\s+(.+?)\s*$/im)?.[1]
+    ?? null
+}
+
+/** Canonical type key (`classDiagram`, `flowchart`, …); `diagram` when unknown. */
+function diagramType(source: string): string {
   const declaration = source.trimStart().match(/^([\w-]+)/)?.[1]?.toLowerCase()
-  const names: Record<string, string> = {
-    flowchart: 'Flowchart',
-    graph: 'Flowchart',
-    sequencediagram: 'Sequence diagram',
-    classdiagram: 'Class diagram',
-    statediagram: 'State diagram',
-    'statediagram-v2': 'State diagram',
-    erdiagram: 'Entity relationship diagram',
-    journey: 'User journey',
-    gantt: 'Gantt chart',
-    pie: 'Pie chart',
-    gitgraph: 'Git graph',
-    mindmap: 'Mindmap',
-    timeline: 'Timeline',
-    quadrantchart: 'Quadrant chart',
-    requirementdiagram: 'Requirement diagram',
-    'xychart-beta': 'XY chart',
-    'sankey-beta': 'Sankey diagram',
-    'block-beta': 'Block diagram',
-    'architecture-beta': 'Architecture diagram',
-    'packet-beta': 'Packet diagram',
-    kanban: 'Kanban board'
-  }
-  return (declaration && names[declaration]) ?? 'Diagram'
+  return (declaration && DIAGRAM_TYPE_KEYS[declaration]) ?? 'diagram'
 }
 
 /**
@@ -133,7 +139,9 @@ export function renderMermaidFlowcharts(html: string, theme: Theme): Promise<str
       const diagram = document.createElement('div')
       diagram.className = 'mermaid-diagram'
       diagram.dataset.mermaidRendered = 'true'
-      diagram.dataset.mermaidName = diagramName(source)
+      diagram.dataset.mermaidType = diagramType(source)
+      const title = diagramTitle(source)
+      if (title) diagram.dataset.mermaidTitle = title
       diagram.innerHTML = safeSvg
       candidate.replaceWith(diagram)
       changed = true

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,6 +1,6 @@
 {
   "app": {
-    "name": "Moji v0.1.3",
+    "name": "Moji v0.1.4",
     "untitled": "Untitled",
     "modifiedMarker": "•"
   },
@@ -77,7 +77,7 @@
     "noDocument": "Open or create a document to see its outline."
   },
   "statusbar": {
-    "brand": "Moji v0.1.3",
+    "brand": "Moji v0.1.4",
     "guide": "Markdown Guide",
     "exportPdf": "Export PDF",
     "lineCount": "Lines: {{count}}",
@@ -91,6 +91,27 @@
     "copyCode": "Copy code",
     "codeCopied": "Code copied",
     "diagramTitle": "Diagram",
+    "diagramTypes": {
+      "flowchart": "Flowchart",
+      "sequenceDiagram": "Sequence diagram",
+      "classDiagram": "Class diagram",
+      "stateDiagram": "State diagram",
+      "erDiagram": "Entity relationship diagram",
+      "journey": "User journey",
+      "gantt": "Gantt chart",
+      "pie": "Pie chart",
+      "gitGraph": "Git graph",
+      "mindmap": "Mindmap",
+      "timeline": "Timeline",
+      "quadrantChart": "Quadrant chart",
+      "requirementDiagram": "Requirement diagram",
+      "xyChart": "XY chart",
+      "sankey": "Sankey diagram",
+      "block": "Block diagram",
+      "architecture": "Architecture diagram",
+      "packet": "Packet diagram",
+      "kanban": "Kanban board"
+    },
     "closeDiagram": "Close diagram",
     "zoomIn": "Zoom in",
     "zoomOut": "Zoom out",
@@ -104,7 +125,7 @@
   },
   "welcome": {
     "tagline": "A lightweight, simple Markdown reader",
-    "title": "Moji v0.1.3",
+    "title": "Moji v0.1.4",
     "subtitle": "Open a Markdown file to read it cleanly.",
     "openButton": "Open File",
     "newButton": "New File",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1,6 +1,6 @@
 {
   "app": {
-    "name": "Moji v0.1.3",
+    "name": "Moji v0.1.4",
     "untitled": "Sin título",
     "modifiedMarker": "•"
   },
@@ -78,7 +78,7 @@
     "noDocument": "Abre o crea un documento para ver su esquema."
   },
   "statusbar": {
-    "brand": "Moji v0.1.3",
+    "brand": "Moji v0.1.4",
     "guide": "Guía de Markdown",
     "exportPdf": "Exportar PDF",
     "lineCount": "Líneas: {{count}}",
@@ -92,6 +92,27 @@
     "copyCode": "Copiar código",
     "codeCopied": "Código copiado",
     "diagramTitle": "Diagrama",
+    "diagramTypes": {
+      "flowchart": "Diagrama de flujo",
+      "sequenceDiagram": "Diagrama de secuencia",
+      "classDiagram": "Diagrama de clases",
+      "stateDiagram": "Diagrama de estados",
+      "erDiagram": "Diagrama entidad-relación",
+      "journey": "Recorrido del usuario",
+      "gantt": "Diagrama de Gantt",
+      "pie": "Gráfico circular",
+      "gitGraph": "Gráfico de Git",
+      "mindmap": "Mapa mental",
+      "timeline": "Línea de tiempo",
+      "quadrantChart": "Gráfico de cuadrantes",
+      "requirementDiagram": "Diagrama de requisitos",
+      "xyChart": "Gráfico XY",
+      "sankey": "Diagrama de Sankey",
+      "block": "Diagrama de bloques",
+      "architecture": "Diagrama de arquitectura",
+      "packet": "Diagrama de paquetes",
+      "kanban": "Tablero Kanban"
+    },
     "closeDiagram": "Cerrar diagrama",
     "zoomIn": "Acercar",
     "zoomOut": "Alejar",
@@ -105,7 +126,7 @@
   },
   "welcome": {
     "tagline": "Un lector de Markdown ligero y sencillo",
-    "title": "Moji v0.1.3",
+    "title": "Moji v0.1.4",
     "subtitle": "Abre un archivo Markdown para leerlo de forma limpia.",
     "openButton": "Abrir archivo",
     "newButton": "Nuevo archivo",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1,6 +1,6 @@
 {
   "app": {
-    "name": "Moji v0.1.3",
+    "name": "Moji v0.1.4",
     "untitled": "無題",
     "modifiedMarker": "•"
   },
@@ -78,7 +78,7 @@
     "noDocument": "ドキュメントを開くか新規作成するとアウトラインが表示されます。"
   },
   "statusbar": {
-    "brand": "Moji v0.1.3",
+    "brand": "Moji v0.1.4",
     "guide": "Markdown ガイド",
     "exportPdf": "PDF をエクスポート",
     "lineCount": "行数: {{count}}",
@@ -92,6 +92,27 @@
     "copyCode": "コードをコピー",
     "codeCopied": "コードをコピーしました",
     "diagramTitle": "図",
+    "diagramTypes": {
+      "flowchart": "フローチャート",
+      "sequenceDiagram": "シーケンス図",
+      "classDiagram": "クラス図",
+      "stateDiagram": "状態遷移図",
+      "erDiagram": "ER図",
+      "journey": "ユーザージャーニー",
+      "gantt": "ガントチャート",
+      "pie": "円グラフ",
+      "gitGraph": "Gitグラフ",
+      "mindmap": "マインドマップ",
+      "timeline": "タイムライン",
+      "quadrantChart": "四象限チャート",
+      "requirementDiagram": "要件図",
+      "xyChart": "XYチャート",
+      "sankey": "サンキー図",
+      "block": "ブロック図",
+      "architecture": "アーキテクチャ図",
+      "packet": "パケット図",
+      "kanban": "カンバンボード"
+    },
     "closeDiagram": "図を閉じる",
     "zoomIn": "拡大",
     "zoomOut": "縮小",
@@ -105,7 +126,7 @@
   },
   "welcome": {
     "tagline": "軽くてシンプルな Markdown リーダー",
-    "title": "Moji v0.1.3",
+    "title": "Moji v0.1.4",
     "subtitle": "Markdown ファイルを開いて、すっきり読めます。",
     "openButton": "ファイルを開く",
     "newButton": "新規ファイル",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -1,6 +1,6 @@
 {
   "app": {
-    "name": "Moji v0.1.3",
+    "name": "Moji v0.1.4",
     "untitled": "Sem título",
     "modifiedMarker": "•"
   },
@@ -77,7 +77,7 @@
     "noDocument": "Abra ou crie um documento para ver o sumário."
   },
   "statusbar": {
-    "brand": "Moji v0.1.3",
+    "brand": "Moji v0.1.4",
     "guide": "Guia de Markdown",
     "exportPdf": "Exportar PDF",
     "lineCount": "Linhas: {{count}}",
@@ -91,6 +91,27 @@
     "copyCode": "Copiar código",
     "codeCopied": "Código copiado",
     "diagramTitle": "Diagrama",
+    "diagramTypes": {
+      "flowchart": "Fluxograma",
+      "sequenceDiagram": "Diagrama de sequência",
+      "classDiagram": "Diagrama de classes",
+      "stateDiagram": "Diagrama de estados",
+      "erDiagram": "Diagrama entidade-relacionamento",
+      "journey": "Jornada do usuário",
+      "gantt": "Gráfico de Gantt",
+      "pie": "Gráfico de pizza",
+      "gitGraph": "Gráfico do Git",
+      "mindmap": "Mapa mental",
+      "timeline": "Linha do tempo",
+      "quadrantChart": "Gráfico de quadrantes",
+      "requirementDiagram": "Diagrama de requisitos",
+      "xyChart": "Gráfico XY",
+      "sankey": "Diagrama de Sankey",
+      "block": "Diagrama de blocos",
+      "architecture": "Diagrama de arquitetura",
+      "packet": "Diagrama de pacotes",
+      "kanban": "Quadro Kanban"
+    },
     "closeDiagram": "Fechar diagrama",
     "zoomIn": "Aumentar zoom",
     "zoomOut": "Diminuir zoom",
@@ -104,7 +125,7 @@
   },
   "welcome": {
     "tagline": "Um leitor de Markdown leve e simples",
-    "title": "Moji v0.1.3",
+    "title": "Moji v0.1.4",
     "subtitle": "Abra um Markdown para ler com clareza, sem distrações.",
     "openButton": "Abrir arquivo",
     "newButton": "Novo Arquivo",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1,6 +1,6 @@
 {
   "app": {
-    "name": "Moji v0.1.3",
+    "name": "Moji v0.1.4",
     "untitled": "Без названия",
     "modifiedMarker": "•"
   },
@@ -78,7 +78,7 @@
     "noDocument": "Откройте или создайте документ, чтобы увидеть его структуру."
   },
   "statusbar": {
-    "brand": "Moji v0.1.3",
+    "brand": "Moji v0.1.4",
     "guide": "Руководство по Markdown",
     "exportPdf": "Экспорт в PDF",
     "lineCount": "Строк: {{count}}",
@@ -92,6 +92,27 @@
     "copyCode": "Копировать код",
     "codeCopied": "Код скопирован",
     "diagramTitle": "Диаграмма",
+    "diagramTypes": {
+      "flowchart": "Блок-схема",
+      "sequenceDiagram": "Диаграмма последовательности",
+      "classDiagram": "Диаграмма классов",
+      "stateDiagram": "Диаграмма состояний",
+      "erDiagram": "ER-диаграмма",
+      "journey": "Путь пользователя",
+      "gantt": "Диаграмма Ганта",
+      "pie": "Круговая диаграмма",
+      "gitGraph": "График Git",
+      "mindmap": "Интеллект-карта",
+      "timeline": "Временная шкала",
+      "quadrantChart": "Квадрантная диаграмма",
+      "requirementDiagram": "Диаграмма требований",
+      "xyChart": "XY-диаграмма",
+      "sankey": "Диаграмма Санки",
+      "block": "Блочная диаграмма",
+      "architecture": "Архитектурная диаграмма",
+      "packet": "Диаграмма пакетов",
+      "kanban": "Доска канбан"
+    },
     "closeDiagram": "Закрыть диаграмму",
     "zoomIn": "Увеличить",
     "zoomOut": "Уменьшить",
@@ -105,7 +126,7 @@
   },
   "welcome": {
     "tagline": "Лёгкая и простая программа для чтения Markdown",
-    "title": "Moji v0.1.3",
+    "title": "Moji v0.1.4",
     "subtitle": "Откройте файл Markdown, чтобы читать его в удобном виде.",
     "openButton": "Открыть файл",
     "newButton": "Новый файл",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -1,6 +1,6 @@
 {
   "app": {
-    "name": "Moji v0.1.3",
+    "name": "Moji v0.1.4",
     "untitled": "无标题",
     "modifiedMarker": "•"
   },
@@ -78,7 +78,7 @@
     "noDocument": "打开或创建一个文档以查看其大纲。"
   },
   "statusbar": {
-    "brand": "Moji v0.1.3",
+    "brand": "Moji v0.1.4",
     "guide": "Markdown 指南",
     "exportPdf": "导出 PDF",
     "lineCount": "行数：{{count}}",
@@ -92,6 +92,27 @@
     "copyCode": "复制代码",
     "codeCopied": "代码已复制",
     "diagramTitle": "图表",
+    "diagramTypes": {
+      "flowchart": "流程图",
+      "sequenceDiagram": "时序图",
+      "classDiagram": "类图",
+      "stateDiagram": "状态图",
+      "erDiagram": "实体关系图",
+      "journey": "用户旅程图",
+      "gantt": "甘特图",
+      "pie": "饼图",
+      "gitGraph": "Git 图",
+      "mindmap": "思维导图",
+      "timeline": "时间线",
+      "quadrantChart": "象限图",
+      "requirementDiagram": "需求图",
+      "xyChart": "XY 图",
+      "sankey": "桑基图",
+      "block": "块图",
+      "architecture": "架构图",
+      "packet": "数据包图",
+      "kanban": "看板"
+    },
     "closeDiagram": "关闭图表",
     "zoomIn": "放大",
     "zoomOut": "缩小",
@@ -105,7 +126,7 @@
   },
   "welcome": {
     "tagline": "轻量简洁的 Markdown 阅读器",
-    "title": "Moji v0.1.3",
+    "title": "Moji v0.1.4",
     "subtitle": "打开 Markdown 文件以清晰地阅读。",
     "openButton": "打开文件",
     "newButton": "新建文件",


### PR DESCRIPTION
## Why

`release/0.1.4` is one commit ahead of `main`, and that commit carries more than a version bump. Without merging it back, those changes live only on the release branch and the next feature branched off `main` would silently drop them.

`main` has nothing that `release/0.1.4` lacks: #7 already merged `main` into the release branch, so this closes the loop.

## What comes back to main

`chore(release): 0.1.4` contains:

- The version bump itself: `package.json`, `package-lock.json`, and the version shown in `src/index.html`.
- Mermaid fixes: `src/lib/mermaid.ts` and `src/components/Preview.tsx`, with `src/lib/mermaid.test.ts` updated alongside.
- **Diagram type names translated into all six locales.** The viewer title used to show a fixed English string; these are the translations behind that fix, and they exist nowhere else.
- `CHANGELOG.md`, `README.md`, `RULES.md` and `DESIGN.md` for 0.1.4.

The macOS support is already on `main` through #6 and #7, so it is not part of this diff.

## Testing

- `npm ci` from a clean tree, then `npm run typecheck`: passes.
- Test suite: 50 pass, 1 fail. The failure is `settings.test.ts > sanitizes persisted preferences and keeps recent files unique`, which already fails on `main` and predates any of this: `settings.ts` caches settings in a module-level variable, and the test does not reset it between cases, so the second case reads the first one's cache. The production code is correct; the test does not isolate. Worth fixing separately, and worth knowing about before any CI is added, since it makes a fresh pipeline start red.
- `npm run dist:mac` from this branch produces `Moji-0.1.4-universal.dmg` (227 MB) and the matching ZIP. `lipo` reports `x86_64 arm64`; `Info.plist` carries version `0.1.4`, the product name `Moji`, and the `.md` document type. Reading the menu back from the packaged bundle gives `Moji | Edit | Window` with `Quit Moji`, confirming the macOS support is really inside the artifact.
