### PR TITLE
docs: explain how to open the unsigned macOS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,27 @@
 </p>
 
 
+## Installing on macOS
+
+macOS will refuse to open Moji the first time, with a message saying it is damaged, or that Apple cannot check it for malicious software. **The app is fine.** Signing an app requires a paid Apple Developer account, and Moji does not have one yet, so macOS treats it as coming from an unidentified developer.
+
+To open it:
+
+1. Drag **Moji** from the DMG into your **Applications** folder.
+2. Double-click it. macOS blocks it. Dismiss the dialog.
+3. Open **System Settings > Privacy & Security**, scroll to the **Security** section, and click **Open Anyway** next to the message about Moji.
+4. Confirm. macOS remembers the choice, so this is a one-time step per version.
+
+> On macOS 15 (Sequoia) and later, Control-clicking the app and choosing *Open* **no longer works**: [Apple removed that override](https://developer.apple.com/news/?id=saqachfa). System Settings is now the only route through the interface.
+
+If you prefer the terminal, this clears the quarantine flag and skips the prompts entirely:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/Moji.app
+```
+
+Because the app is unsigned, macOS also keeps automatic updates disabled: download a new DMG to upgrade. Both limitations disappear the day the app is signed and notarized.
+
 ## Name
 
 **Moji (文字)** literally means "letter", "character", or "writing" in Japanese. Short and easy to remember, it evokes characters and writing. The name fits its purpose: opening, editing, previewing, and exporting Markdown smoothly—without distractions.
@@ -112,7 +133,7 @@ File associations for `.md` and `.markdown` are declared in `electron-builder.ym
 
 macOS releases are **not code-signed or notarized**, because that requires a paid Apple Developer account. Consequences:
 
-- Gatekeeper quarantines the app when the DMG is downloaded from the web. Users must either right-click the app and choose *Open*, or clear the quarantine flag: `xattr -dr com.apple.quarantine /Applications/Moji.app`.
+- Gatekeeper blocks the app when the DMG is downloaded from the web. Users open it through **System Settings > Privacy & Security > Open Anyway**, or by clearing the quarantine flag with `xattr -dr com.apple.quarantine /Applications/Moji.app`. Control-clicking the app and choosing *Open* stopped working in macOS 15 (Sequoia), where [Apple removed that override](https://developer.apple.com/news/?id=saqachfa). See [Installing on macOS](#installing-on-macos).
 - Automatic updates stay disabled on macOS. Squirrel.Mac refuses to replace an unsigned bundle, so `updater.ts` reports `unsupported` there and users update by downloading a new DMG.
 
 To sign locally, install an Apple Developer ID certificate in the keychain and drop the `CSC_IDENTITY_AUTO_DISCOVERY=false` override; `build/entitlements.mac.plist` and `hardenedRuntime` are already configured for notarization.


### PR DESCRIPTION
## Problem

The macOS build is unsigned, so the first launch is blocked by Gatekeeper. The README covers this, but in two ways that fail the person who needs it.

**It is in the wrong place.** The advice lives under *Packaging*, written for someone building the app. Somebody who just downloaded the DMG never scrolls there, sees a dialog claiming Moji is damaged, and concludes the release is broken.

**And it is wrong.** It tells users to right-click the app and choose *Open*. That override **no longer exists**: [Apple removed it in macOS 15 Sequoia](https://developer.apple.com/news/?id=saqachfa).

> In macOS Sequoia, users will no longer be able to Control-click to override Gatekeeper when opening software that isn't signed correctly or notarized. They'll need to visit System Settings > Privacy & Security to review security information for software before allowing it to run.

So the current instructions send users down a path that quietly does nothing on any current macOS.

## Fix

A short **Installing on macOS** section right under the download links, in user language:

- Says plainly that the app is fine, and that the warning comes from the missing paid Apple certificate.
- Gives the route that actually works today: **System Settings > Privacy & Security > Open Anyway**.
- Keeps `xattr -dr com.apple.quarantine /Applications/Moji.app` as the terminal alternative.
- Notes that the same missing signature is why automatic updates are off on macOS.

The Packaging section is corrected too, and now links to the new section instead of repeating stale advice.

## Testing

Checked against the machine and the artifact rather than from memory:

- `sw_vers` reports macOS **26.5.1**, well past the Sequoia change.
- `spctl --assess --type execute` on the built app: `rejected, source=no usable signature`. `codesign -dvv` shows `Signature=adhoc`, no Team ID. So Gatekeeper really does block this artifact, and the instructions are needed.
- The removal of the Control-click override is confirmed by Apple's own developer note, linked above and quoted in the README.

Documentation only. No code changes.
