### PR TITLE
docs: move the install instructions out of the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,27 +26,6 @@
 </p>
 
 
-## Installing on macOS
-
-macOS will refuse to open Moji the first time, with a message saying it is damaged, or that Apple cannot check it for malicious software. **The app is fine.** Signing an app requires a paid Apple Developer account, and Moji does not have one yet, so macOS treats it as coming from an unidentified developer.
-
-To open it:
-
-1. Drag **Moji** from the DMG into your **Applications** folder.
-2. Double-click it. macOS blocks it. Dismiss the dialog.
-3. Open **System Settings > Privacy & Security**, scroll to the **Security** section, and click **Open Anyway** next to the message about Moji.
-4. Confirm. macOS remembers the choice, so this is a one-time step per version.
-
-> On macOS 15 (Sequoia) and later, Control-clicking the app and choosing *Open* **no longer works**: [Apple removed that override](https://developer.apple.com/news/?id=saqachfa). System Settings is now the only route through the interface.
-
-If you prefer the terminal, this clears the quarantine flag and skips the prompts entirely:
-
-```bash
-xattr -dr com.apple.quarantine /Applications/Moji.app
-```
-
-Because the app is unsigned, macOS also keeps automatic updates disabled: download a new DMG to upgrade. Both limitations disappear the day the app is signed and notarized.
-
 ## Name
 
 **Moji (文字)** literally means "letter", "character", or "writing" in Japanese. Short and easy to remember, it evokes characters and writing. The name fits its purpose: opening, editing, previewing, and exporting Markdown smoothly—without distractions.
@@ -86,6 +65,29 @@ Because the app is unsigned, macOS also keeps automatic updates disabled: downlo
   <img src="docs/scr-export.jpg" alt="Export" width="45%" />
 </p>
 
+
+## Installation
+
+Windows and Linux install from the downloads above with no extra steps.
+
+### macOS
+
+macOS refuses to open Moji the first time, saying it is damaged or that Apple cannot check it for malicious software. **The app is fine.** Signing an app requires a paid Apple Developer account, which Moji does not have yet, so macOS treats it as coming from an unidentified developer.
+
+1. Drag **Moji** from the DMG into your **Applications** folder.
+2. Double-click it. macOS blocks it. Dismiss the dialog.
+3. Open **System Settings > Privacy & Security**, scroll to the **Security** section, and click **Open Anyway** next to the message about Moji.
+4. Confirm. macOS remembers the choice, so this is a one-time step per version.
+
+> Control-clicking the app and choosing *Open* **no longer works** on macOS 15 (Sequoia) and later: [Apple removed that override](https://developer.apple.com/news/?id=saqachfa). System Settings is the only route through the interface.
+
+If you prefer the terminal, clearing the quarantine flag skips the prompts entirely:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/Moji.app
+```
+
+The missing signature is also why automatic updates stay off on macOS: upgrade by downloading a new DMG. Both limitations disappear once the app is signed and notarized.
 
 ## Requirements
 
@@ -133,7 +135,7 @@ File associations for `.md` and `.markdown` are declared in `electron-builder.ym
 
 macOS releases are **not code-signed or notarized**, because that requires a paid Apple Developer account. Consequences:
 
-- Gatekeeper blocks the app when the DMG is downloaded from the web. Users open it through **System Settings > Privacy & Security > Open Anyway**, or by clearing the quarantine flag with `xattr -dr com.apple.quarantine /Applications/Moji.app`. Control-clicking the app and choosing *Open* stopped working in macOS 15 (Sequoia), where [Apple removed that override](https://developer.apple.com/news/?id=saqachfa). See [Installing on macOS](#installing-on-macos).
+- Gatekeeper blocks the app when the DMG is downloaded from the web. Users open it through **System Settings > Privacy & Security > Open Anyway**, or by clearing the quarantine flag with `xattr -dr com.apple.quarantine /Applications/Moji.app`. Control-clicking the app and choosing *Open* stopped working in macOS 15 (Sequoia), where [Apple removed that override](https://developer.apple.com/news/?id=saqachfa). The user-facing steps live under [Installation](#macos).
 - Automatic updates stay disabled on macOS. Squirrel.Mac refuses to replace an unsigned bundle, so `updater.ts` reports `unsupported` there and users update by downloading a new DMG.
 
 To sign locally, install an Apple Developer ID certificate in the keychain and drop the `CSC_IDENTITY_AUTO_DISCOVERY=false` override; `build/entitlements.mac.plist` and `hardenedRuntime` are already configured for notarization.


### PR DESCRIPTION
## Problem

#9 put the macOS install instructions in the wrong place: between the download links and `## Name`. That makes an operating-system warning the very first thing a visitor reads about Moji, before the README has said what the app is. My mistake.

It also spoke only to macOS users, leaving everyone else to scroll past a section that does not apply to them.

## Fix

The content is unchanged. It moves into a proper **`## Installation`** section, placed after **Screenshots** and before **Requirements**.

That boundary is where the README turns from the product to the toolchain: `Requirements`, `Development`, and `Packaging` all address someone who is going to build the project. Installation is the last thing a plain user needs, so it closes their half of the document.

The section now opens by saying Windows and Linux need no extra steps, and only then goes into `### macOS`, where the friction actually is.

The internal link from the Packaging section pointed at `#installing-on-macos`, which the rename removed. It now points at `#macos`.

## Testing

Documentation only. Heading structure after the change:

```
## Name
## Features
## Screenshots
## Installation
### macOS
## Requirements
## Development
## Packaging
### macOS builds
### Publishing a release
## Project Structure
## Documentation
## License
```

No orphan anchors remain.
