### PR TITLE
Fix Markdown preview link opening

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,13 +1,15 @@
 import { app, BrowserWindow, dialog, ipcMain, Menu, shell } from 'electron'
-import { readFile, writeFile } from 'node:fs/promises'
+import { readFile, stat, writeFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { dirname, extname, isAbsolute, join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import {
   IPC,
   MARKDOWN_EXTENSIONS,
   SUPPORTED_LANGUAGES,
   type ImageDataResult,
   type Language,
+  type OpenLocalPathResult,
   type OpenManyResult,
   type OpenResult,
   type Settings,
@@ -45,6 +47,7 @@ app.setName('Moji')
 app.setPath('userData', join(app.getPath('appData'), SETTINGS_DIRECTORY))
 
 const IMAGE_EXTENSIONS = new Set(['.avif', '.bmp', '.gif', '.ico', '.jpeg', '.jpg', '.png', '.svg', '.webp'])
+const EXTERNAL_URL_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:'])
 const SAMPLE_FILES = new Set([
   'markdown-guide.en.md',
   'markdown-guide.pt-BR.md',
@@ -176,6 +179,57 @@ async function readDocument(filePath: unknown): Promise<OpenResult> {
   } catch (err) {
     return { ok: false, error: (err as Error).message }
   }
+}
+
+async function openLocalPath(filePath: unknown): Promise<OpenLocalPathResult> {
+  if (typeof filePath !== 'string' || !isAbsolute(filePath)) return { ok: false, error: 'unsupported' }
+
+  try {
+    const fileStat = await stat(filePath)
+    if (fileStat.isFile() && isMarkdown(filePath)) {
+      const result = await readDocument(filePath)
+      return result.ok
+        ? { ok: true, type: 'file', document: { path: result.path, content: result.content } }
+        : result
+    }
+
+    if (!fileStat.isFile() && !fileStat.isDirectory()) return { ok: false, error: 'unsupported' }
+
+    const error = await shell.openPath(filePath)
+    return error ? { ok: false, error } : { ok: true, type: 'external', path: filePath }
+  } catch (err) {
+    return { ok: false, error: (err as Error).message }
+  }
+}
+
+function sendOpenLocalPathResult(result: OpenLocalPathResult): void {
+  if (!mainWindow || !result.ok || result.type !== 'file') return
+  mainWindow.webContents.send(IPC.openDocument, result.document)
+}
+
+async function openLocalFileUrl(fileUrl: string): Promise<void> {
+  try {
+    sendOpenLocalPathResult(await openLocalPath(fileURLToPath(fileUrl)))
+  } catch {
+    /* Ignore invalid file URLs blocked from navigation. */
+  }
+}
+
+function openExternalUrl(url: string): boolean {
+  try {
+    if (!EXTERNAL_URL_PROTOCOLS.has(new URL(url).protocol)) return false
+    void shell.openExternal(url)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function isAppNavigationUrl(url: string): boolean {
+  const devUrl = process.env['ELECTRON_RENDERER_URL']
+  if (devUrl) return url.startsWith(devUrl)
+  const rendererUrl = pathToFileURL(join(__dirname, '../renderer/index.html')).toString()
+  return url === rendererUrl || url.startsWith(`${rendererUrl}#`)
 }
 
 /** Single funnel for every open entry point (association, CLI, dialog, drop). */
@@ -313,17 +367,16 @@ function createWindow(): void {
     }
   })
 
-  // Open external links in the OS browser, never in-app.
+  // Open links outside Chromium navigation so document state never gets replaced.
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    if (url.startsWith('http:') || url.startsWith('https:')) void shell.openExternal(url)
+    if (!openExternalUrl(url) && url.startsWith('file:')) void openLocalFileUrl(url)
     return { action: 'deny' }
   })
 
   mainWindow.webContents.on('will-navigate', (event, url) => {
-    const devUrl = process.env['ELECTRON_RENDERER_URL']
-    if ((devUrl && url.startsWith(devUrl)) || (!devUrl && url.startsWith('file://'))) return
+    if (isAppNavigationUrl(url)) return
     event.preventDefault()
-    if (url.startsWith('http:') || url.startsWith('https:')) void shell.openExternal(url)
+    if (!openExternalUrl(url) && url.startsWith('file:')) void openLocalFileUrl(url)
   })
 
   // Close guard: ask the renderer before closing when there are unsaved edits.
@@ -384,6 +437,8 @@ function registerIpc(): void {
         .map(({ path, content }) => ({ path, content }))
     }
   })
+
+  ipcMain.handle(IPC.openLocalPath, (_e, filePath: unknown): Promise<OpenLocalPathResult> => openLocalPath(filePath))
 
   ipcMain.handle(IPC.readPath, (_e, filePath: unknown): Promise<OpenResult> => readDocument(filePath))
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -5,6 +5,7 @@ import {
   type DocumentPayload,
   type ExportRequest,
   type ImageDataResult,
+  type OpenLocalPathResult,
   type OpenManyResult,
   type OpenResult,
   type Settings,
@@ -17,6 +18,7 @@ const api = {
   setSettings: (patch: Partial<Settings>): Promise<Settings> => ipcRenderer.invoke(IPC.setSettings, patch),
 
   openDialog: (): Promise<OpenManyResult> => ipcRenderer.invoke(IPC.openDialog),
+  openLocalPath: (filePath: string): Promise<OpenLocalPathResult> => ipcRenderer.invoke(IPC.openLocalPath, filePath),
   readPath: (filePath: string): Promise<OpenResult> => ipcRenderer.invoke(IPC.readPath, filePath),
   readImageAsDataUrl: (filePath: string): Promise<ImageDataResult> => ipcRenderer.invoke(IPC.readImage, filePath),
   readSample: (sampleName: string): Promise<OpenResult> => ipcRenderer.invoke(IPC.readSample, sampleName),

--- a/electron/shared.ts
+++ b/electron/shared.ts
@@ -56,6 +56,12 @@ export type ImageDataResult =
   | { ok: true; dataUrl: string }
   | { ok: false; error?: string }
 
+/** Result of opening a local path from a Markdown preview link. */
+export type OpenLocalPathResult =
+  | { ok: true; type: 'file'; document: DocumentPayload }
+  | { ok: true; type: 'external'; path: string }
+  | { ok: false; error?: string }
+
 export type UpdateStatus =
   | 'unsupported'
   | 'idle'
@@ -109,6 +115,7 @@ export interface DiagramPngRequest {
 /** IPC channel names. */
 export const IPC = {
   openDialog: 'file:open-dialog',
+  openLocalPath: 'file:open-local-path',
   readPath: 'file:read-path',
   readImage: 'file:read-image',
   readSample: 'file:read-sample',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -520,6 +520,21 @@ export function App(): JSX.Element {
     [addDocuments, flash, forgetRecent, rememberRecent, t]
   )
 
+  const openLocalPath = useCallback(
+    async (path: string) => {
+      const res = await window.api.openLocalPath(path)
+      if (res.ok && res.type === 'file') {
+        addDocuments([{ path: res.document.path, content: res.document.content }])
+        rememberRecent([res.document.path])
+      } else if (!res.ok && res.error === 'unsupported') {
+        flash(t('notice.unsupported'), true)
+      } else if (!res.ok) {
+        flash(t('notice.openFailed', { error: res.error }), true)
+      }
+    },
+    [addDocuments, flash, rememberRecent, t]
+  )
+
   const openRecent = useCallback((path: string) => void openPaths([path]), [openPaths])
 
   const openExportDialog = useCallback(
@@ -1233,6 +1248,8 @@ export function App(): JSX.Element {
                 mdTheme={mdTheme}
                 searchTerm={searchTerm}
                 settings={settings}
+                documentPath={activeDoc?.path}
+                onOpenLocalPath={(path) => void openLocalPath(path)}
               />
             )}
           </div>

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type MouseEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { Settings, Theme } from '../../electron/shared'
+import { localPathFromPreviewHref } from '../lib/markdown'
 import { scrollPreviewHeadingIntoView } from '../lib/previewScroll'
 import { renderMermaidFlowcharts } from '../lib/mermaid'
 import { MermaidDiagramDialog, type DiagramContent } from './MermaidDiagramDialog'
@@ -11,7 +12,9 @@ interface PreviewProps {
   mdTheme: Theme
   searchTerm: string
   settings: Settings
+  documentPath?: string | null
   className?: string
+  onOpenLocalPath?: (path: string) => void
 }
 
 interface ActiveDiagram {
@@ -47,7 +50,16 @@ function graphicContent(graphic: PreviewGraphic): DiagramContent {
 }
 
 /** Renders sanitized Markdown HTML and resolves in-document heading anchors. */
-export function Preview({ html, documentName, mdTheme, searchTerm, settings, className }: PreviewProps): JSX.Element {
+export function Preview({
+  html,
+  documentName,
+  mdTheme,
+  searchTerm,
+  settings,
+  documentPath,
+  className,
+  onOpenLocalPath
+}: PreviewProps): JSX.Element {
   const { t } = useTranslation()
   const bodyRef = useRef<HTMLDivElement>(null)
   const [renderedHtml, setRenderedHtml] = useState(html)
@@ -116,10 +128,17 @@ export function Preview({ html, documentName, mdTheme, searchTerm, settings, cla
       const target =
         bodyRef.current?.querySelector(`#${CSS.escape(id)}`) ?? document.getElementById(id)
       if (target instanceof HTMLElement) scrollPreviewHeadingIntoView(target)
+      return
+    }
+
+    const localPath = localPathFromPreviewHref(href, documentPath)
+    if (localPath) {
+      e.preventDefault()
+      onOpenLocalPath?.(localPath)
     }
     // External http(s) links carry target="_blank"; the main process opens them
     // in the OS browser via the window-open handler.
-  }, [openDiagramAt, t])
+  }, [documentPath, onOpenLocalPath, openDiagramAt, t])
 
   useEffect(() => {
     if (!bodyRef.current) return

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest'
-import { documentAssetBaseUrl, findMarkdownHeadingLine, renderMarkdown } from './markdown'
+import { documentAssetBaseUrl, findMarkdownHeadingLine, localPathFromPreviewHref, renderMarkdown } from './markdown'
 
 describe('documentAssetBaseUrl', () => {
   it('converts Windows paths to an encoded file URL', () => {
@@ -64,6 +64,35 @@ describe('renderMarkdown', () => {
 
     expect(html).toContain('<pre class="hljs mermaid-diagram-candidate">')
     expect(html).toContain('<code>flowchart TD')
+  })
+})
+
+describe('localPathFromPreviewHref', () => {
+  it('resolves relative links against the active document path', () => {
+    expect(localPathFromPreviewHref('docs/next%20file.md', '/home/me/notes/index.md')).toBe(
+      '/home/me/notes/docs/next file.md'
+    )
+  })
+
+  it('resolves file URLs to local paths', () => {
+    expect(localPathFromPreviewHref('file:///home/me/notes/next%20file.md', null)).toBe(
+      '/home/me/notes/next file.md'
+    )
+  })
+
+  it('keeps absolute local paths and ignores heading fragments', () => {
+    expect(localPathFromPreviewHref('/home/me/notes/next%20file.md#intro', null)).toBe(
+      '/home/me/notes/next file.md'
+    )
+  })
+
+  it('ignores in-document anchors and external URLs', () => {
+    expect(localPathFromPreviewHref('#intro', '/home/me/notes/index.md')).toBeNull()
+    expect(localPathFromPreviewHref('https://example.com/docs.md', '/home/me/notes/index.md')).toBeNull()
+  })
+
+  it('does not resolve relative links when no document path is available', () => {
+    expect(localPathFromPreviewHref('docs/next.md', null)).toBeNull()
   })
 })
 

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -69,6 +69,9 @@ DOMPurify.addHook('afterSanitizeAttributes', (node) => {
 
 const EMPTY_IMAGE =
   'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=='
+const URL_SCHEME_RE = /^[A-Za-z][A-Za-z\d+.-]*:/
+const WINDOWS_DRIVE_PATH_RE = /^[A-Za-z]:[\\/]/
+const UNC_PATH_RE = /^\\\\/
 
 function filePathToFileUrl(filePath: string): string {
   const normalized = filePath.replace(/\\/g, '/')
@@ -88,11 +91,57 @@ function prepareAppImage(image: Element, filePath: string): void {
   image.setAttribute('src', EMPTY_IMAGE)
 }
 
-function fileUrlToPath(fileUrl: string): string {
+export function fileUrlToPath(fileUrl: string): string {
   const url = new URL(fileUrl)
   const pathname = decodeURIComponent(url.pathname)
   if (url.hostname) return `//${url.hostname}${pathname}`
   return /^\/[A-Za-z]:\//.test(pathname) ? pathname.slice(1) : pathname
+}
+
+function stripUrlSuffix(value: string): string {
+  const cutAt = [value.indexOf('#'), value.indexOf('?')].filter((index) => index >= 0)
+  return cutAt.length > 0 ? value.slice(0, Math.min(...cutAt)) : value
+}
+
+function decodePathLike(value: string): string {
+  try {
+    return decodeURI(value)
+  } catch {
+    return value
+  }
+}
+
+function isAbsoluteLocalHref(value: string): boolean {
+  return WINDOWS_DRIVE_PATH_RE.test(value) || UNC_PATH_RE.test(value) || (value.startsWith('/') && !value.startsWith('//'))
+}
+
+export function localPathFromPreviewHref(href: string, documentPath: string | null | undefined): string | null {
+  const value = href.trim()
+  if (!value || value.startsWith('#')) return null
+
+  if (isAbsoluteLocalHref(value)) {
+    return decodePathLike(stripUrlSuffix(value).replace(/\\/g, '/'))
+  }
+
+  if (URL_SCHEME_RE.test(value)) {
+    if (!value.toLowerCase().startsWith('file:')) return null
+    try {
+      return fileUrlToPath(value)
+    } catch {
+      return null
+    }
+  }
+
+  if (value.startsWith('//')) return null
+
+  const baseUrl = documentAssetBaseUrl(documentPath)
+  if (!baseUrl) return null
+
+  try {
+    return fileUrlToPath(new URL(value.replace(/\\/g, '/'), baseUrl).toString())
+  } catch {
+    return null
+  }
 }
 
 export function documentAssetBaseUrl(documentPath: string | null | undefined): string | null {


### PR DESCRIPTION
# Why
Markdown should open like a document, not a project. When a reader clicks a link inside a Markdown document, Moji should keep the document experience intact: external links go to the system browser, and local document links open safely through the app instead of replacing the preview.

# What this does
- Routes external Markdown links through Electron's `shell.openExternal`.
- Intercepts local preview links and sends them through typed IPC.
- Opens linked Markdown files as Moji documents, folders as workspaces, and other local files through the OS.
- Adds path/link parsing coverage for relative links, file URLs, absolute local paths, fragments, and unsupported schemes.

# Testing
- `npm run typecheck`
- `npm test`

# Limitations, stated up front
- This does not add a new link-management UI.
- Unsupported or invalid paths still fail with the existing open-failed/unsupported feedback.