### PR TITLE
Add AUR binary package recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+- AUR `moji-bin` package recipe for installation with `yay -S moji-bin`.
+
 ## [0.1.4] - 2026-07-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@
 
 Windows and Linux install from the downloads above with no extra steps.
 
+### Arch Linux
+
+Moji can be installed from the AUR binary package:
+
+```bash
+yay -S moji-bin
+```
+
+The AUR recipe lives in `aur/moji-bin/` and installs the GitHub Releases AppImage with desktop integration.
+
 ### macOS
 
 macOS refuses to open Moji the first time, saying it is damaged or that Apple cannot check it for malicious software. **The app is fine.** Signing an app requires a paid Apple Developer account, which Moji does not have yet, so macOS treats it as coming from an unidentified developer.
@@ -176,6 +186,7 @@ src/
   styles/        Theme tokens, app shell CSS, Markdown preview CSS
 
 samples/         Bundled Markdown documents (full Markdown guide)
+aur/moji-bin/    AUR binary package recipe for yay/pacman installation
 ```
 
 ## Documentation

--- a/aur/moji-bin/.SRCINFO
+++ b/aur/moji-bin/.SRCINFO
@@ -1,0 +1,21 @@
+pkgbase = moji-bin
+	pkgdesc = Clean Markdown viewer and editor
+	pkgver = 0.1.4
+	pkgrel = 1
+	url = https://github.com/alexishida/Moji
+	arch = x86_64
+	license = MIT
+	depends = bash
+	depends = fuse2
+	depends = hicolor-icon-theme
+	depends = zlib
+	provides = moji
+	conflicts = moji
+	options = !strip
+	options = !debug
+	source_x86_64 = Moji-0.1.4-x86_64.AppImage::https://github.com/alexishida/Moji/releases/download/v0.1.4/Moji-0.1.4-x86_64.AppImage
+	source_x86_64 = LICENSE::https://github.com/alexishida/Moji/raw/v0.1.4/LICENSE
+	sha256sums_x86_64 = 3cb66cf761178dcef5c99b3d321342f2e4506ce04660c509523be9fcf91c2017
+	sha256sums_x86_64 = 1f9e1485d9d027196dc04363fc1e58aed158b7745f00c1818394abcb6e401e6d
+
+pkgname = moji-bin

--- a/aur/moji-bin/PKGBUILD
+++ b/aur/moji-bin/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: Alex Ishida <alexishida@gmail.com>
+
+pkgname=moji-bin
+pkgver=0.1.4
+pkgrel=1
+pkgdesc='Clean Markdown viewer and editor'
+arch=('x86_64')
+url='https://github.com/alexishida/Moji'
+license=('MIT')
+depends=('bash' 'fuse2' 'hicolor-icon-theme' 'zlib')
+provides=('moji')
+conflicts=('moji')
+options=('!strip' '!debug')
+
+_appimage="Moji-${pkgver}-${CARCH}.AppImage"
+source_x86_64=(
+  "${_appimage}::${url}/releases/download/v${pkgver}/${_appimage}"
+  "LICENSE::${url}/raw/v${pkgver}/LICENSE"
+)
+sha256sums_x86_64=(
+  '3cb66cf761178dcef5c99b3d321342f2e4506ce04660c509523be9fcf91c2017'
+  '1f9e1485d9d027196dc04363fc1e58aed158b7745f00c1818394abcb6e401e6d'
+)
+
+prepare() {
+  chmod +x "${_appimage}"
+  "./${_appimage}" --appimage-extract >/dev/null
+  sed -i 's|^Exec=.*|Exec=moji %U|' squashfs-root/moji.desktop
+}
+
+package() {
+  install -Dm755 "${_appimage}" "${pkgdir}/usr/lib/moji/moji.AppImage"
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+  install -Dm644 squashfs-root/moji.desktop "${pkgdir}/usr/share/applications/moji.desktop"
+  install -Dm644 squashfs-root/usr/share/mime/packages/moji.xml "${pkgdir}/usr/share/mime/packages/moji.xml"
+  cp -dr --no-preserve=ownership squashfs-root/usr/share/icons "${pkgdir}/usr/share/"
+  chmod -R u=rwX,go=rX "${pkgdir}/usr/share/icons"
+
+  install -Dm755 /dev/stdin "${pkgdir}/usr/bin/moji" <<'EOF'
+#!/bin/sh
+exec /usr/lib/moji/moji.AppImage --no-sandbox "$@"
+EOF
+}


### PR DESCRIPTION
# Why
Moji is built to make Markdown feel like a document: double-click, read immediately, no setup. Arch users expect app distribution through the AUR, so adding a `moji-bin` recipe makes Moji easier to install inside that ecosystem without changing the app's lightweight desktop flow.

# What this does
- Adds `aur/moji-bin/PKGBUILD` and `.SRCINFO`.
- Packages the published Linux AppImage from GitHub Releases.
- Installs desktop integration, MIME metadata, icons, license, and a `/usr/bin/moji` launcher.
- Documents `yay -S moji-bin` in the README.

# Testing
- `makepkg --printsrcinfo`
- `makepkg -sf`
- `npm run typecheck`
- `npm test`

# Limitations, stated up front
- This is a binary AUR recipe for the existing AppImage, not a source-built Arch package.
- Version and checksums must be updated for each Moji release.
- AUR publication itself still requires pushing this recipe to the AUR repository after this PR lands.